### PR TITLE
Remove eis-public-repo from parent and aml pom.xml

### DIFF
--- a/dataformat-aml/pom.xml
+++ b/dataformat-aml/pom.xml
@@ -138,11 +138,4 @@
             </plugin>
         </plugins>
     </build>
-    <repositories>
-        <repository>
-            <id>eis-public-repo</id>
-            <name>maven-public</name>
-            <url>https://maven.iais.fraunhofer.de/artifactory/eis-ids-public</url>
-        </repository>
-    </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -201,14 +201,6 @@
         </repository>
     </distributionManagement>
 
-    <repositories>
-        <repository>
-            <id>eis-public-repo</id>
-            <name>maven-public</name>
-            <url>https://maven.iais.fraunhofer.de/artifactory/eis-ids-public</url>
-        </repository>
-    </repositories>
-
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>


### PR DESCRIPTION
Old repo entry is not needed anymore after Maven Central release.
This could lead to diverging jars with same versions.