### PR TITLE
Finalizing the maven push workflow

### DIFF
--- a/.github/workflows/maven-deploy-to-maven-central.yml
+++ b/.github/workflows/maven-deploy-to-maven-central.yml
@@ -1,0 +1,34 @@
+# This workflow will deploy the Serializers and the Validator to the sonatype
+# staging environment. This will NOT automatically publish the artifacts. An
+# authorized user must still manually close the staging repository first.
+
+name: Generate and Deploy to Sonatype
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: 'adopt'
+          server-id: ossrh
+          server-username: OSSRH_USERNAME
+          server-password: OSSRH_PASSWORD
+          gpg-private-key: ${{ secrets.MYGPGKEY_SEC }}
+
+      - name: Publish to Apache Maven Central
+        run: mvn -P MavenCentral license:format deploy
+        env:
+          OSSRH_USERNAME: sebbader
+          OSSRH_PASSWORD: ${{ secrets.SEBBADER_OSSHR_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_KEY_PASSWORD }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_KEY_PASSWORD }}

--- a/pom.xml
+++ b/pom.xml
@@ -187,10 +187,6 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
                         <version>${plugin.gpg.version}</version>
-                        <configuration>
-                            <keyname>${gpg.keyname}</keyname>
-                            <passphraseServerId>${gpg.keyname}</passphraseServerId>
-                        </configuration>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -203,7 +199,7 @@
                     </plugin>
                 </plugins>
             </build>
-            
+
             <!-- Central Repository deployment configuration -->
             <distributionManagement>
                 <snapshotRepository>


### PR DESCRIPTION
This PR introduces a GitHub workflow to push the serializers and the validators to Maven Central. This workflow fires every time something is pushed to the `main` branch.

Note: Two out of three required secrets are still missing, so it will not work today (as of 19.11.2021). However, here is a proof that the workflow file is working: https://github.com/sebbader/java-serializer/actions/runs/1481535857 
Which resulted to a deployed repository at the sonatype nexus:
![grafik](https://user-images.githubusercontent.com/12392907/142646073-3f3c68cf-4177-4522-b8bd-f121c9662e04.png)
