### PR TITLE
Bugfix/aml serializer

### DIFF
--- a/dataformat-aml/src/main/java/io/adminshell/aas/v3/dataformat/aml/deserialization/Aml2AasMapper.java
+++ b/dataformat-aml/src/main/java/io/adminshell/aas/v3/dataformat/aml/deserialization/Aml2AasMapper.java
@@ -25,11 +25,11 @@ import io.adminshell.aas.v3.dataformat.aml.common.naming.PropertyNamingStrategy;
 import io.adminshell.aas.v3.dataformat.mapping.MappingException;
 import io.adminshell.aas.v3.dataformat.mapping.MappingProvider;
 import io.adminshell.aas.v3.model.AssetAdministrationShellEnvironment;
+import io.adminshell.aas.v3.model.AssetInformation;
 import io.adminshell.aas.v3.model.Identifiable;
 import io.adminshell.aas.v3.model.MultiLanguageProperty;
 import io.adminshell.aas.v3.model.Referable;
 import io.adminshell.aas.v3.model.Qualifiable;
-
 
 import java.util.List;
 
@@ -64,8 +64,8 @@ public class Aml2AasMapper {
         mappingProvider.register(new LangStringCollectionMapper());
         mappingProvider.register(new RelationshipElementMapper());
         mappingProvider.register(new ReferenceElementMapper());
-        mappingProvider.register(new ReferableMapper<Referable>());
-        mappingProvider.register(new IdentifiableMapper<Identifiable>());
+        mappingProvider.register(new ReferableMapper<>());
+        mappingProvider.register(new IdentifiableMapper<>());
         mappingProvider.register(new ConstraintCollectionMapper());
         mappingProvider.register(new QualifierMapper());
         mappingProvider.register(new OperationCollectionMapper());
@@ -77,12 +77,15 @@ public class Aml2AasMapper {
         mappingProvider.register(new EmbeddedDataSpecificationCollectionMapper());
         mappingProvider.register(new DataSpecificationIEC61360Mapper());
         mappingProvider.register(new EnumDataTypeIEC61360Mapper());
+        mappingProvider.register(new IdentifierKeyValuePairCollectionMapper());
+
         AbstractClassNamingStrategy classNamingStrategy = new NumberingClassNamingStrategy();
 
         PropertyNamingStrategy propertyNamingStrategy = new PropertyNamingStrategy();
         propertyNamingStrategy.registerCustomNaming(Referable.class, "descriptions", "description");
         propertyNamingStrategy.registerCustomNaming(MultiLanguageProperty.class, "values", "value");
-        propertyNamingStrategy.registerCustomNaming(Qualifiable.class, "qualifiers", "qualifier","qualifier");
+        propertyNamingStrategy.registerCustomNaming(Qualifiable.class, "qualifiers", "qualifier", "qualifier");
+        propertyNamingStrategy.registerCustomNaming(AssetInformation.class, "specificAssetIds", "specificAssetId");
         MappingContext context = new MappingContext(mappingProvider, classNamingStrategy, propertyNamingStrategy, config.getTypeFactory());
         context.setDocumentInfo(AmlDocumentInfo.fromFile(aml));
         AssetAdministrationShellEnvironment result = context.map(AssetAdministrationShellEnvironment.class, parser);

--- a/dataformat-aml/src/main/java/io/adminshell/aas/v3/dataformat/aml/deserialization/mappers/AssetAdministrationShellEnvironmentMapper.java
+++ b/dataformat-aml/src/main/java/io/adminshell/aas/v3/dataformat/aml/deserialization/mappers/AssetAdministrationShellEnvironmentMapper.java
@@ -73,7 +73,7 @@ public class AssetAdministrationShellEnvironmentMapper implements Mapper<AssetAd
         CAEXFile.SystemUnitClassLib systemUnitClassLib = parser.getContent().getSystemUnitClassLib().stream()
                 .filter(x -> x.getName().equalsIgnoreCase(ASSET_ADMINISTRATION_SHELL_SYSTEM_UNIT_CLASSES))
                 .findFirst()
-                .orElse(null);
+                .orElse(CAEXFile.SystemUnitClassLib.builder().build());
 
         List<SystemUnitFamilyType> systemUnitFamilyTypeShells = systemUnitClassLib.getSystemUnitClass().stream()
                 .filter(x ->x.getSupportedRoleClass().get(0).getRefRoleClassPath().equalsIgnoreCase(ROLE_CLASS_LIB_ASSET_ADMINISTRATION_SHELL))

--- a/dataformat-aml/src/main/java/io/adminshell/aas/v3/dataformat/aml/deserialization/mappers/IdentifierKeyValuePairCollectionMapper.java
+++ b/dataformat-aml/src/main/java/io/adminshell/aas/v3/dataformat/aml/deserialization/mappers/IdentifierKeyValuePairCollectionMapper.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2021 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e. V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.adminshell.aas.v3.dataformat.aml.deserialization.mappers;
+
+import io.adminshell.aas.v3.dataformat.aml.deserialization.AmlParser;
+import io.adminshell.aas.v3.dataformat.aml.deserialization.DefaultMapper;
+import io.adminshell.aas.v3.dataformat.aml.deserialization.MappingContext;
+import io.adminshell.aas.v3.dataformat.aml.model.caex.AttributeType;
+import io.adminshell.aas.v3.dataformat.aml.model.caex.CAEXObject;
+import io.adminshell.aas.v3.dataformat.core.util.AasUtils;
+import io.adminshell.aas.v3.dataformat.mapping.MappingException;
+import io.adminshell.aas.v3.model.IdentifierKeyValuePair;
+import java.beans.PropertyDescriptor;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class IdentifierKeyValuePairCollectionMapper extends DefaultMapper<Collection<IdentifierKeyValuePair>> {
+
+    @Override
+    protected Collection mapCollectionValueProperty(AmlParser parser, MappingContext context) throws MappingException {
+        Collection result = new ArrayList<>();
+        CAEXObject current = parser.getCurrent();
+        AttributeType parent = findAttribute(current, context.getProperty(), context);
+        if (parent == null) {
+            return result;
+        }
+        List<AttributeType> attributes = findAttributes(parent, x -> x.getName().startsWith("specificAssetId"));
+        for (AttributeType attribute : attributes) {
+            parser.setCurrent(attribute);
+            try {
+                IdentifierKeyValuePair element = context.getTypeFactory().newInstance(IdentifierKeyValuePair.class);
+                for (PropertyDescriptor property : AasUtils.getAasProperties(IdentifierKeyValuePair.class)) {
+                    Object propertyValue = context
+                            .with(element)
+                            .with(property)
+                            .withoutType()
+                            .map(property.getReadMethod().getGenericReturnType(), parser);
+                    if (propertyValue != null) {
+                        try {
+                            property.getWriteMethod().invoke(element, propertyValue);
+                        } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
+                            throw new MappingException(String.format("error setting property value for property %s", property.getName()), ex);
+                        }
+                    }
+                }
+                parser.setCurrent(attribute);
+                result.add(element);
+            } catch (NoSuchMethodException ex) {
+                Logger.getLogger(IdentifierKeyValuePairCollectionMapper.class.getName()).log(Level.SEVERE, null, ex);
+            } catch (InstantiationException ex) {
+                Logger.getLogger(IdentifierKeyValuePairCollectionMapper.class.getName()).log(Level.SEVERE, null, ex);
+            } catch (IllegalAccessException ex) {
+                Logger.getLogger(IdentifierKeyValuePairCollectionMapper.class.getName()).log(Level.SEVERE, null, ex);
+            } catch (IllegalArgumentException ex) {
+                Logger.getLogger(IdentifierKeyValuePairCollectionMapper.class.getName()).log(Level.SEVERE, null, ex);
+            } catch (InvocationTargetException ex) {
+                Logger.getLogger(IdentifierKeyValuePairCollectionMapper.class.getName()).log(Level.SEVERE, null, ex);
+            }
+        }
+        parser.setCurrent(parent);
+        return result;
+    }
+
+}

--- a/dataformat-aml/src/main/java/io/adminshell/aas/v3/dataformat/aml/serialization/AasToAmlMapper.java
+++ b/dataformat-aml/src/main/java/io/adminshell/aas/v3/dataformat/aml/serialization/AasToAmlMapper.java
@@ -38,6 +38,7 @@ import io.adminshell.aas.v3.dataformat.aml.serialization.mappers.SubmodelMapper;
 import io.adminshell.aas.v3.dataformat.aml.serialization.mappers.ViewMapper;
 import io.adminshell.aas.v3.dataformat.aml.model.caex.CAEXFile;
 import io.adminshell.aas.v3.dataformat.aml.serialization.mappers.ConceptDescriptionMapper;
+import io.adminshell.aas.v3.dataformat.aml.serialization.mappers.IdentifierKeyValuePairCollectionMapper;
 import io.adminshell.aas.v3.dataformat.aml.serialization.mappers.PropertyMapper;
 import io.adminshell.aas.v3.dataformat.aml.serialization.mappers.RangeMapper;
 import io.adminshell.aas.v3.dataformat.aml.serialization.mappers.ReferenceMapper;
@@ -99,6 +100,7 @@ public class AasToAmlMapper {
         mappingProvider.register(new PropertyMapper());
         mappingProvider.register(new RangeMapper());
         mappingProvider.register(new ConceptDescriptionMapper());
+        mappingProvider.register(new IdentifierKeyValuePairCollectionMapper());
         MappingContext context = new MappingContext(
                 mappingProvider,
                 classNamingStrategy,

--- a/dataformat-aml/src/main/java/io/adminshell/aas/v3/dataformat/aml/serialization/mappers/IdentifierKeyValuePairCollectionMapper.java
+++ b/dataformat-aml/src/main/java/io/adminshell/aas/v3/dataformat/aml/serialization/mappers/IdentifierKeyValuePairCollectionMapper.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e. V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.adminshell.aas.v3.dataformat.aml.serialization.mappers;
+
+import io.adminshell.aas.v3.dataformat.aml.serialization.DefaultMapper;
+import io.adminshell.aas.v3.dataformat.aml.serialization.AmlGenerator;
+import io.adminshell.aas.v3.dataformat.aml.serialization.MappingContext;
+import io.adminshell.aas.v3.dataformat.aml.model.caex.AttributeType;
+import io.adminshell.aas.v3.dataformat.core.util.AasUtils;
+import io.adminshell.aas.v3.dataformat.mapping.MappingException;
+import io.adminshell.aas.v3.model.AssetInformation;
+import io.adminshell.aas.v3.model.IdentifierKeyValuePair;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class IdentifierKeyValuePairCollectionMapper extends DefaultMapper<Collection<IdentifierKeyValuePair>> {
+
+    private static final String ATTRIBUTE_NAME = "specificAssetId";
+
+    @Override
+    public void map(Collection<IdentifierKeyValuePair> value, AmlGenerator generator, MappingContext context) throws MappingException {
+        if (value == null || context == null || value.isEmpty()) {
+            return;
+        }
+        AttributeType.Builder wrapperBuilder = AttributeType.builder()
+                .withName(ATTRIBUTE_NAME)
+                .withRefSemantic(generator.refSemantic(AssetInformation.class, ATTRIBUTE_NAME));
+        List<AttributeType> attributes = new ArrayList<>();
+        for (IdentifierKeyValuePair element : value) {
+            AttributeType.Builder builder = AttributeType.builder()
+                    .withName(ATTRIBUTE_NAME + (value.size() > 1 ? "_" + (attributes.size() + 1) : ""));
+            for (PropertyDescriptor property : AasUtils.getAasProperties(element.getClass())) {
+                if (!skipProperty(property)) {
+                    context.with(property)
+                            .map(property.getReadMethod().getGenericReturnType(),
+                                    getElemenetPropertyValue(element, property, context),
+                                    generator.with(builder));
+                }
+            }
+            attributes.add(builder.build());
+        }
+        attributes.forEach(x -> wrapperBuilder.addAttribute(x));
+        generator.add(wrapperBuilder.build());
+    }
+
+    protected Object getElemenetPropertyValue(IdentifierKeyValuePair elemenet, PropertyDescriptor property, MappingContext context) throws MappingException {
+        try {
+            return property.getReadMethod().invoke(elemenet);
+        } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
+            throw new MappingException("failed to get property value for property " + property.getName(), ex);
+        }
+    }
+}

--- a/dataformat-aml/src/test/java/io/adminshell/aas/v3/dataformat/aml/fixtures/SimpleExample.java
+++ b/dataformat-aml/src/test/java/io/adminshell/aas/v3/dataformat/aml/fixtures/SimpleExample.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e. V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.adminshell.aas.v3.dataformat.aml.fixtures;
+
+public class SimpleExample {
+
+    public static final java.io.File FILE = new java.io.File("src/test/resources/test_demo_simple_example.aml");
+
+}

--- a/dataformat-aml/src/test/java/io/adminshell/aas/v3/dataformat/aml/serialize/AmlSerializerTest.java
+++ b/dataformat-aml/src/test/java/io/adminshell/aas/v3/dataformat/aml/serialize/AmlSerializerTest.java
@@ -15,12 +15,15 @@
  */
 package io.adminshell.aas.v3.dataformat.aml.serialize;
 
+import io.adminshell.aas.v3.dataformat.DeserializationException;
 import io.adminshell.aas.v3.dataformat.aml.fixtures.FullExample;
 import io.adminshell.aas.v3.dataformat.SerializationException;
 import io.adminshell.aas.v3.dataformat.aml.AmlSerializationConfig;
 import io.adminshell.aas.v3.dataformat.aml.AmlSerializer;
+import io.adminshell.aas.v3.dataformat.aml.fixtures.SimpleExample;
 import io.adminshell.aas.v3.dataformat.aml.serialization.id.IntegerIdGenerator;
 import io.adminshell.aas.v3.dataformat.core.AASFull;
+import io.adminshell.aas.v3.dataformat.core.AASSimple;
 import io.adminshell.aas.v3.model.AssetAdministrationShellEnvironment;
 import java.io.File;
 import java.io.IOException;
@@ -39,6 +42,11 @@ public class AmlSerializerTest {
     @Test
     public void testSAPFullExample() throws SerializationException, SAXException, IOException {
         validateAmlSerializer(FullExample.FILE, AASFull.ENVIRONMENT);
+    }
+
+    @Test
+    public void testSimpleExample() throws SerializationException, SAXException, IOException, DeserializationException {
+        validateAmlSerializer(SimpleExample.FILE, AASSimple.ENVIRONMENT);
     }
 
     private void validateAmlSerializer(File expectedFile, AssetAdministrationShellEnvironment environment)

--- a/dataformat-aml/src/test/resources/test_demo_simple_example.aml
+++ b/dataformat-aml/src/test/resources/test_demo_simple_example.aml
@@ -1,0 +1,1964 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CAEXFile FileName="AssetAdministrationShellEnvironment.aml" SchemaVersion="2.15">
+    <AdditionalInformation AutomationMLVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string"/>
+    <InstanceHierarchy Name="AssetAdministrationShellInstanceHierarchy">
+        <InternalElement ID="12" Name="ExampleMotor">
+            <Attribute Name="assetInformation">
+                <RefSemantic CorrespondingAttributePath="AAS:AssetAdministrationShell/assetInformation"/>
+                <Attribute Name="assetKind">
+                    <Value>INSTANCE</Value>
+                    <RefSemantic CorrespondingAttributePath="AAS:AssetInformation/assetKind"/>
+                </Attribute>
+                <Attribute Name="globalAssetId">
+                    <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">(Asset)[IRI]http://customer.com/assets/KHBVZJSQKIY</Value>
+                    <RefSemantic CorrespondingAttributePath="AAS:AssetInformation/globalAssetId"/>
+                </Attribute>
+                <Attribute Name="specificAssetId">
+                    <RefSemantic CorrespondingAttributePath="AAS:AssetInformation/specificAssetId"/>
+                    <Attribute Name="specificAssetId_1">
+                        <Attribute Name="externalSubjectId">
+                            <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">(GlobalReference)[IRI]http://customer.com/Systems/ERP/012</Value>
+                            <RefSemantic CorrespondingAttributePath="AAS:IdentifierKeyValuePair/externalSubjectId"/>
+                        </Attribute>
+                        <Attribute Name="key">
+                            <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">EquipmentID</Value>
+                            <RefSemantic CorrespondingAttributePath="AAS:IdentifierKeyValuePair/key"/>
+                        </Attribute>
+                        <Attribute Name="value">
+                            <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">538fd1b3-f99f-4a52-9c75-72e9fa921270</Value>
+                            <RefSemantic CorrespondingAttributePath="AAS:IdentifierKeyValuePair/value"/>
+                        </Attribute>
+                    </Attribute>
+                    <Attribute Name="specificAssetId_2">
+                        <Attribute Name="externalSubjectId">
+                            <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">(GlobalReference)[IRI]http://customer.com/Systems/IoT/1</Value>
+                            <RefSemantic CorrespondingAttributePath="AAS:IdentifierKeyValuePair/externalSubjectId"/>
+                        </Attribute>
+                        <Attribute Name="key">
+                            <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">DeviceID</Value>
+                            <RefSemantic CorrespondingAttributePath="AAS:IdentifierKeyValuePair/key"/>
+                        </Attribute>
+                        <Attribute Name="value">
+                            <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">QjYgPggjwkiHk4RrQiYSLg==</Value>
+                            <RefSemantic CorrespondingAttributePath="AAS:IdentifierKeyValuePair/value"/>
+                        </Attribute>
+                    </Attribute>
+                </Attribute>
+            </Attribute>
+            <Attribute Name="idShort">
+                <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">ExampleMotor</Value>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+            </Attribute>
+            <Attribute Name="identification">
+                <RefSemantic CorrespondingAttributePath="AAS:Identifiable/identification"/>
+                <Attribute Name="idType">
+                    <Value>IRI</Value>
+                    <RefSemantic CorrespondingAttributePath="AAS:Identifier/idType"/>
+                </Attribute>
+                <Attribute Name="identifier">
+                    <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">http://customer.com/aas/9175_7013_7091_9168</Value>
+                    <RefSemantic CorrespondingAttributePath="AAS:Identifier/identifier"/>
+                </Attribute>
+            </Attribute>
+            <InternalElement ID="4" Name="TechnicalData">
+                <Attribute Name="idShort">
+                    <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">TechnicalData</Value>
+                    <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+                </Attribute>
+                <Attribute Name="identification">
+                    <RefSemantic CorrespondingAttributePath="AAS:Identifiable/identification"/>
+                    <Attribute Name="idType">
+                        <Value>IRI</Value>
+                        <RefSemantic CorrespondingAttributePath="AAS:Identifier/idType"/>
+                    </Attribute>
+                    <Attribute Name="identifier">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">http://i40.customer.com/type/1/1/7A7104BDAB57E184</Value>
+                        <RefSemantic CorrespondingAttributePath="AAS:Identifier/identifier"/>
+                    </Attribute>
+                </Attribute>
+                <Attribute Name="kind">
+                    <Value>INSTANCE</Value>
+                    <RefSemantic CorrespondingAttributePath="AAS:HasKind/kind"/>
+                </Attribute>
+                <Attribute Name="semanticId">
+                    <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">(GlobalReference)[IRDI]0173-1#01-AFZ615#016</Value>
+                    <RefSemantic CorrespondingAttributePath="AAS:HasSemantics/semanticId"/>
+                </Attribute>
+                <InternalElement ID="3" Name="MaxRotationSpeed">
+                    <Attribute Name="category">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">Parameter</Value>
+                        <RefSemantic CorrespondingAttributePath="AAS:Referable/category"/>
+                    </Attribute>
+                    <Attribute Name="idShort">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">MaxRotationSpeed</Value>
+                        <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+                    </Attribute>
+                    <Attribute Name="kind">
+                        <Value>INSTANCE</Value>
+                        <RefSemantic CorrespondingAttributePath="AAS:HasKind/kind"/>
+                    </Attribute>
+                    <Attribute Name="semanticId">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">(ConceptDescription)[IRDI]0173-1#02-BAA120#008</Value>
+                        <RefSemantic CorrespondingAttributePath="AAS:HasSemantics/semanticId"/>
+                    </Attribute>
+                    <Attribute Name="value" AttributeDataType="xs:integer">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">5000</Value>
+                        <RefSemantic CorrespondingAttributePath="AAS:Property/value"/>
+                    </Attribute>
+                    <RoleRequirements RefBaseRoleClassPath="AssetAdministrationShellRoleClassLib/Property"/>
+                </InternalElement>
+                <RoleRequirements RefBaseRoleClassPath="AssetAdministrationShellRoleClassLib/Submodel"/>
+            </InternalElement>
+            <InternalElement ID="6" Name="OperationalData">
+                <Attribute Name="idShort">
+                    <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">OperationalData</Value>
+                    <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+                </Attribute>
+                <Attribute Name="identification">
+                    <RefSemantic CorrespondingAttributePath="AAS:Identifiable/identification"/>
+                    <Attribute Name="idType">
+                        <Value>IRI</Value>
+                        <RefSemantic CorrespondingAttributePath="AAS:Identifier/idType"/>
+                    </Attribute>
+                    <Attribute Name="identifier">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">http://i40.customer.com/instance/1/1/AC69B1CB44F07935</Value>
+                        <RefSemantic CorrespondingAttributePath="AAS:Identifier/identifier"/>
+                    </Attribute>
+                </Attribute>
+                <Attribute Name="kind">
+                    <Value>INSTANCE</Value>
+                    <RefSemantic CorrespondingAttributePath="AAS:HasKind/kind"/>
+                </Attribute>
+                <InternalElement ID="5" Name="RotationSpeed">
+                    <Attribute Name="category">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">Variable</Value>
+                        <RefSemantic CorrespondingAttributePath="AAS:Referable/category"/>
+                    </Attribute>
+                    <Attribute Name="idShort">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">RotationSpeed</Value>
+                        <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+                    </Attribute>
+                    <Attribute Name="kind">
+                        <Value>INSTANCE</Value>
+                        <RefSemantic CorrespondingAttributePath="AAS:HasKind/kind"/>
+                    </Attribute>
+                    <Attribute Name="semanticId">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">(ConceptDescription)[IRI]http://customer.com/cd/1/1/18EBD56F6B43D895</Value>
+                        <RefSemantic CorrespondingAttributePath="AAS:HasSemantics/semanticId"/>
+                    </Attribute>
+                    <Attribute Name="value" AttributeDataType="xs:integer">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">4370</Value>
+                        <RefSemantic CorrespondingAttributePath="AAS:Property/value"/>
+                    </Attribute>
+                    <RoleRequirements RefBaseRoleClassPath="AssetAdministrationShellRoleClassLib/Property"/>
+                </InternalElement>
+                <RoleRequirements RefBaseRoleClassPath="AssetAdministrationShellRoleClassLib/Submodel"/>
+            </InternalElement>
+            <InternalElement ID="11" Name="Documentation">
+                <Attribute Name="idShort">
+                    <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">Documentation</Value>
+                    <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+                </Attribute>
+                <Attribute Name="identification">
+                    <RefSemantic CorrespondingAttributePath="AAS:Identifiable/identification"/>
+                    <Attribute Name="idType">
+                        <Value>IRI</Value>
+                        <RefSemantic CorrespondingAttributePath="AAS:Identifier/idType"/>
+                    </Attribute>
+                    <Attribute Name="identifier">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">http://i40.customer.com/type/1/1/1A7B62B529F19152</Value>
+                        <RefSemantic CorrespondingAttributePath="AAS:Identifier/identifier"/>
+                    </Attribute>
+                </Attribute>
+                <Attribute Name="kind">
+                    <Value>INSTANCE</Value>
+                    <RefSemantic CorrespondingAttributePath="AAS:HasKind/kind"/>
+                </Attribute>
+                <InternalElement ID="10" Name="OperatingManual">
+                    <Attribute Name="allowDuplicates">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:boolean">false</Value>
+                        <RefSemantic CorrespondingAttributePath="AAS:SubmodelElementCollection/allowDuplicates"/>
+                    </Attribute>
+                    <Attribute Name="idShort">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">OperatingManual</Value>
+                        <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+                    </Attribute>
+                    <Attribute Name="kind">
+                        <Value>INSTANCE</Value>
+                        <RefSemantic CorrespondingAttributePath="AAS:HasKind/kind"/>
+                    </Attribute>
+                    <Attribute Name="ordered">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:boolean">false</Value>
+                        <RefSemantic CorrespondingAttributePath="AAS:SubmodelElementCollection/ordered"/>
+                    </Attribute>
+                    <Attribute Name="semanticId">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">(ConceptDescription)[IRI]www.vdi2770.com/blatt1/Entwurf/Okt18/cd/Document</Value>
+                        <RefSemantic CorrespondingAttributePath="AAS:HasSemantics/semanticId"/>
+                    </Attribute>
+                    <InternalElement ID="7" Name="Title">
+                        <Attribute Name="idShort">
+                            <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">Title</Value>
+                            <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+                        </Attribute>
+                        <Attribute Name="kind">
+                            <Value>INSTANCE</Value>
+                            <RefSemantic CorrespondingAttributePath="AAS:HasKind/kind"/>
+                        </Attribute>
+                        <Attribute Name="semanticId">
+                            <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">(ConceptDescription)[IRI]www.vdi2770.com/blatt1/Entwurf/Okt18/cd/Description/Title</Value>
+                            <RefSemantic CorrespondingAttributePath="AAS:HasSemantics/semanticId"/>
+                        </Attribute>
+                        <Attribute Name="value" AttributeDataType="xs:langString">
+                            <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">OperatingManual</Value>
+                            <RefSemantic CorrespondingAttributePath="AAS:Property/value"/>
+                        </Attribute>
+                        <RoleRequirements RefBaseRoleClassPath="AssetAdministrationShellRoleClassLib/Property"/>
+                    </InternalElement>
+                    <InternalElement ID="9" Name="DigitalFile_PDF">
+                        <Attribute Name="idShort">
+                            <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">DigitalFile_PDF</Value>
+                            <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+                        </Attribute>
+                        <Attribute Name="kind">
+                            <Value>INSTANCE</Value>
+                            <RefSemantic CorrespondingAttributePath="AAS:HasKind/kind"/>
+                        </Attribute>
+                        <Attribute Name="mimeType">
+                            <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">application/pdf</Value>
+                            <RefSemantic CorrespondingAttributePath="AAS:File/mimeType"/>
+                        </Attribute>
+                        <Attribute Name="semanticId">
+                            <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">(ConceptDescription)[IRI]www.vdi2770.com/blatt1/Entwurf/Okt18/cd/StoredDocumentRepresentation/DigitalFile</Value>
+                            <RefSemantic CorrespondingAttributePath="AAS:HasSemantics/semanticId"/>
+                        </Attribute>
+                        <Attribute Name="value">
+                            <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">/aasx/OperatingManual.pdf</Value>
+                            <RefSemantic CorrespondingAttributePath="AAS:File/value"/>
+                        </Attribute>
+                        <ExternalInterface ID="8" Name="FileDataReference" RefBaseClassPath="AssetAdministrationShellInterfaceClassLib/FileDataReference">
+                            <Attribute Name="MIMEType" AttributeDataType="xs:string">
+                                <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">application/pdf</Value>
+                                <RefSemantic CorrespondingAttributePath="AAS:File/MIMEType"/>
+                            </Attribute>
+                            <Attribute Name="refURI" AttributeDataType="xs:anyURI">
+                                <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">/aasx/OperatingManual.pdf</Value>
+                                <RefSemantic CorrespondingAttributePath="AAS:File/refURI"/>
+                            </Attribute>
+                        </ExternalInterface>
+                        <RoleRequirements RefBaseRoleClassPath="AssetAdministrationShellRoleClassLib/File"/>
+                    </InternalElement>
+                    <RoleRequirements RefBaseRoleClassPath="AssetAdministrationShellRoleClassLib/SubmodelElementCollection"/>
+                </InternalElement>
+                <RoleRequirements RefBaseRoleClassPath="AssetAdministrationShellRoleClassLib/Submodel"/>
+            </InternalElement>
+            <RoleRequirements RefBaseRoleClassPath="AssetAdministrationShellRoleClassLib/AssetAdministrationShell"/>
+        </InternalElement>
+    </InstanceHierarchy>
+    <InstanceHierarchy Name="ConceptDescriptionInstanceHierarchy">
+        <InternalElement ID="15" Name="Title">
+            <Attribute Name="idShort">
+                <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">Title</Value>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+            </Attribute>
+            <Attribute Name="identification">
+                <RefSemantic CorrespondingAttributePath="AAS:Identifiable/identification"/>
+                <Attribute Name="idType">
+                    <Value>IRI</Value>
+                    <RefSemantic CorrespondingAttributePath="AAS:Identifier/idType"/>
+                </Attribute>
+                <Attribute Name="identifier">
+                    <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">www.vdi2770.com/blatt1/Entwurf/Okt18/cd/Description/Title</Value>
+                    <RefSemantic CorrespondingAttributePath="AAS:Identifier/identifier"/>
+                </Attribute>
+            </Attribute>
+            <InternalElement ID="14" Name="EmbeddedDataSpecification" RefBaseSystemUnitPath="AssetAdministrationShellDataSpecificationTemplates/DataSpecificationIEC61360Template/DataSpecificationIEC61360">
+                <Attribute Name="dataType">
+                    <Value>STRING_TRANSLATABLE</Value>
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/dataType"/>
+                </Attribute>
+                <Attribute Name="definitions">
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/definitions"/>
+                    <Attribute Name="aml-lang=EN">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">SprachabhängigerTiteldesDokuments.</Value>
+                    </Attribute>
+                </Attribute>
+                <Attribute Name="preferredNames">
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/preferredNames"/>
+                    <Attribute Name="aml-lang=EN">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">Title</Value>
+                    </Attribute>
+                    <Attribute Name="aml-lang=DE">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">Titel</Value>
+                    </Attribute>
+                </Attribute>
+                <Attribute Name="shortNames">
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/shortNames"/>
+                    <Attribute Name="aml-lang=EN">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">Title</Value>
+                    </Attribute>
+                    <Attribute Name="aml-lang=DE">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">Titel</Value>
+                    </Attribute>
+                </Attribute>
+                <Attribute Name="sourceOfDefinition">
+                    <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">ExampleString</Value>
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/sourceOfDefinition"/>
+                </Attribute>
+                <Attribute Name="unit">
+                    <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">ExampleString</Value>
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/unit"/>
+                </Attribute>
+                <RoleRequirements RefBaseRoleClassPath="AssetAdministrationShellRoleClassLib/DataSpecificationContent"/>
+            </InternalElement>
+            <RoleRequirements RefBaseRoleClassPath="AssetAdministrationShellRoleClassLib/ConceptDescription"/>
+        </InternalElement>
+        <InternalElement ID="18" Name="DigitalFile">
+            <Attribute Name="idShort">
+                <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">DigitalFile</Value>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+            </Attribute>
+            <Attribute Name="identification">
+                <RefSemantic CorrespondingAttributePath="AAS:Identifiable/identification"/>
+                <Attribute Name="idType">
+                    <Value>IRI</Value>
+                    <RefSemantic CorrespondingAttributePath="AAS:Identifier/idType"/>
+                </Attribute>
+                <Attribute Name="identifier">
+                    <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">www.vdi2770.com/blatt1/Entwurf/Okt18/cd/StoredDocumentRepresentation/DigitalFile</Value>
+                    <RefSemantic CorrespondingAttributePath="AAS:Identifier/identifier"/>
+                </Attribute>
+            </Attribute>
+            <InternalElement ID="17" Name="EmbeddedDataSpecification" RefBaseSystemUnitPath="AssetAdministrationShellDataSpecificationTemplates/DataSpecificationIEC61360Template/DataSpecificationIEC61360">
+                <Attribute Name="dataType">
+                    <Value>STRING</Value>
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/dataType"/>
+                </Attribute>
+                <Attribute Name="definitions">
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/definitions"/>
+                    <Attribute Name="aml-lang=EN">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">A file representing the document version. In addition to the mandatory PDF file, other files can be specified.</Value>
+                    </Attribute>
+                </Attribute>
+                <Attribute Name="preferredNames">
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/preferredNames"/>
+                    <Attribute Name="aml-lang=EN">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">DigitalFile</Value>
+                    </Attribute>
+                    <Attribute Name="aml-lang=EN">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">DigitalFile</Value>
+                    </Attribute>
+                </Attribute>
+                <Attribute Name="shortNames">
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/shortNames"/>
+                    <Attribute Name="aml-lang=EN">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">DigitalFile</Value>
+                    </Attribute>
+                    <Attribute Name="aml-lang=DE">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">DigitaleDatei</Value>
+                    </Attribute>
+                </Attribute>
+                <Attribute Name="sourceOfDefinition">
+                    <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">ExampleString</Value>
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/sourceOfDefinition"/>
+                </Attribute>
+                <Attribute Name="unit">
+                    <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">ExampleString</Value>
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/unit"/>
+                </Attribute>
+                <RoleRequirements RefBaseRoleClassPath="AssetAdministrationShellRoleClassLib/DataSpecificationContent"/>
+            </InternalElement>
+            <RoleRequirements RefBaseRoleClassPath="AssetAdministrationShellRoleClassLib/ConceptDescription"/>
+        </InternalElement>
+        <InternalElement ID="21" Name="MaxRotationSpeed">
+            <Attribute Name="administration">
+                <RefSemantic CorrespondingAttributePath="AAS:Identifiable/administration"/>
+                <Attribute Name="revision">
+                    <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">2.1</Value>
+                    <RefSemantic CorrespondingAttributePath="AAS:AdministrativeInformation/revision"/>
+                </Attribute>
+                <Attribute Name="version">
+                    <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">2</Value>
+                    <RefSemantic CorrespondingAttributePath="AAS:AdministrativeInformation/version"/>
+                </Attribute>
+            </Attribute>
+            <Attribute Name="category">
+                <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">PROPERTY</Value>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/category"/>
+            </Attribute>
+            <Attribute Name="idShort">
+                <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">MaxRotationSpeed</Value>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+            </Attribute>
+            <Attribute Name="identification">
+                <RefSemantic CorrespondingAttributePath="AAS:Identifiable/identification"/>
+                <Attribute Name="idType">
+                    <Value>IRDI</Value>
+                    <RefSemantic CorrespondingAttributePath="AAS:Identifier/idType"/>
+                </Attribute>
+                <Attribute Name="identifier">
+                    <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">0173-1#02-BAA120#008</Value>
+                    <RefSemantic CorrespondingAttributePath="AAS:Identifier/identifier"/>
+                </Attribute>
+            </Attribute>
+            <InternalElement ID="20" Name="EmbeddedDataSpecification" RefBaseSystemUnitPath="AssetAdministrationShellDataSpecificationTemplates/DataSpecificationIEC61360Template/DataSpecificationIEC61360">
+                <Attribute Name="dataType">
+                    <Value>REAL_MEASURE</Value>
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/dataType"/>
+                </Attribute>
+                <Attribute Name="definitions">
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/definitions"/>
+                    <Attribute Name="aml-lang=de">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">HöchstezulässigeDrehzahl,mitwelcherderMotoroderdieSpeiseinheitbetriebenwerdendarf</Value>
+                    </Attribute>
+                    <Attribute Name="aml-lang=EN">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">Greatestpermissiblerotationspeedwithwhichthemotororfeedingunitmaybeoperated</Value>
+                    </Attribute>
+                </Attribute>
+                <Attribute Name="preferredNames">
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/preferredNames"/>
+                    <Attribute Name="aml-lang=de">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">max.Drehzahl</Value>
+                    </Attribute>
+                    <Attribute Name="aml-lang=en">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">Max.rotationspeed</Value>
+                    </Attribute>
+                </Attribute>
+                <Attribute Name="sourceOfDefinition">
+                    <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">ExampleString</Value>
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/sourceOfDefinition"/>
+                </Attribute>
+                <Attribute Name="unit">
+                    <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">1/min</Value>
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/unit"/>
+                </Attribute>
+                <Attribute Name="unitId">
+                    <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">(GlobalReference)[IRDI]0173-1#05-AAA650#002</Value>
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/unitId"/>
+                </Attribute>
+                <RoleRequirements RefBaseRoleClassPath="AssetAdministrationShellRoleClassLib/DataSpecificationContent"/>
+            </InternalElement>
+            <RoleRequirements RefBaseRoleClassPath="AssetAdministrationShellRoleClassLib/ConceptDescription"/>
+        </InternalElement>
+        <InternalElement ID="24" Name="RotationSpeed">
+            <Attribute Name="category">
+                <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">PROPERTY</Value>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/category"/>
+            </Attribute>
+            <Attribute Name="idShort">
+                <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">RotationSpeed</Value>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+            </Attribute>
+            <Attribute Name="identification">
+                <RefSemantic CorrespondingAttributePath="AAS:Identifiable/identification"/>
+                <Attribute Name="idType">
+                    <Value>IRI</Value>
+                    <RefSemantic CorrespondingAttributePath="AAS:Identifier/idType"/>
+                </Attribute>
+                <Attribute Name="identifier">
+                    <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">http://customer.com/cd/1/1/18EBD56F6B43D895</Value>
+                    <RefSemantic CorrespondingAttributePath="AAS:Identifier/identifier"/>
+                </Attribute>
+            </Attribute>
+            <InternalElement ID="23" Name="EmbeddedDataSpecification" RefBaseSystemUnitPath="AssetAdministrationShellDataSpecificationTemplates/DataSpecificationIEC61360Template/DataSpecificationIEC61360">
+                <Attribute Name="dataType">
+                    <Value>REAL_MEASURE</Value>
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/dataType"/>
+                </Attribute>
+                <Attribute Name="definitions">
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/definitions"/>
+                    <Attribute Name="aml-lang=DE">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">Aktuelle Drehzahl, mitwelcher der Motor oder die Speiseinheit betrieben wird</Value>
+                    </Attribute>
+                    <Attribute Name="aml-lang=EN">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">Actual rotationspeed with which the motor or feedingunit is operated</Value>
+                    </Attribute>
+                </Attribute>
+                <Attribute Name="preferredNames">
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/preferredNames"/>
+                    <Attribute Name="aml-lang=DE">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">AktuelleDrehzahl</Value>
+                    </Attribute>
+                    <Attribute Name="aml-lang=EN">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">Actualrotationspeed</Value>
+                    </Attribute>
+                </Attribute>
+                <Attribute Name="shortNames">
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/shortNames"/>
+                    <Attribute Name="aml-lang=DE">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">AktuelleDrehzahl</Value>
+                    </Attribute>
+                    <Attribute Name="aml-lang=EN">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">ActualRotationSpeed</Value>
+                    </Attribute>
+                </Attribute>
+                <Attribute Name="sourceOfDefinition">
+                    <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">ExampleString</Value>
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/sourceOfDefinition"/>
+                </Attribute>
+                <Attribute Name="unit">
+                    <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">1/min</Value>
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/unit"/>
+                </Attribute>
+                <Attribute Name="unitId">
+                    <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">(GlobalReference)[IRDI]0173-1#05-AAA650#002</Value>
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/unitId"/>
+                </Attribute>
+                <RoleRequirements RefBaseRoleClassPath="AssetAdministrationShellRoleClassLib/DataSpecificationContent"/>
+            </InternalElement>
+            <RoleRequirements RefBaseRoleClassPath="AssetAdministrationShellRoleClassLib/ConceptDescription"/>
+        </InternalElement>
+        <InternalElement ID="27" Name="Document">
+            <Attribute Name="idShort">
+                <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">Document</Value>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+            </Attribute>
+            <Attribute Name="identification">
+                <RefSemantic CorrespondingAttributePath="AAS:Identifiable/identification"/>
+                <Attribute Name="idType">
+                    <Value>IRI</Value>
+                    <RefSemantic CorrespondingAttributePath="AAS:Identifier/idType"/>
+                </Attribute>
+                <Attribute Name="identifier">
+                    <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">www.vdi2770.com/blatt1/Entwurf/Okt18/cd/Document</Value>
+                    <RefSemantic CorrespondingAttributePath="AAS:Identifier/identifier"/>
+                </Attribute>
+            </Attribute>
+            <InternalElement ID="26" Name="EmbeddedDataSpecification" RefBaseSystemUnitPath="AssetAdministrationShellDataSpecificationTemplates/DataSpecificationIEC61360Template/DataSpecificationIEC61360">
+                <Attribute Name="dataType">
+                    <Value>STRING</Value>
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/dataType"/>
+                </Attribute>
+                <Attribute Name="definitions">
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/definitions"/>
+                    <Attribute Name="aml-lang=EN">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">Feste und geordnete Menge von für die Verwendung durch Personen bestimmte Informationen, die verwaltet und als Einheit zwischen Benutzern und System ausgetauscht werden kann.</Value>
+                    </Attribute>
+                </Attribute>
+                <Attribute Name="preferredNames">
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/preferredNames"/>
+                    <Attribute Name="aml-lang=EN">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">Document</Value>
+                    </Attribute>
+                </Attribute>
+                <Attribute Name="shortNames">
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/shortNames"/>
+                    <Attribute Name="aml-lang=EN">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">Document</Value>
+                    </Attribute>
+                    <Attribute Name="aml-lang=DE">
+                        <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">Dokument</Value>
+                    </Attribute>
+                </Attribute>
+                <Attribute Name="sourceOfDefinition">
+                    <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">[ISO15519-1:2010]</Value>
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/sourceOfDefinition"/>
+                </Attribute>
+                <Attribute Name="unit">
+                    <Value xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">ExampleString</Value>
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/unit"/>
+                </Attribute>
+                <RoleRequirements RefBaseRoleClassPath="AssetAdministrationShellRoleClassLib/DataSpecificationContent"/>
+            </InternalElement>
+            <RoleRequirements RefBaseRoleClassPath="AssetAdministrationShellRoleClassLib/ConceptDescription"/>
+        </InternalElement>
+    </InstanceHierarchy>
+    <InterfaceClassLib Name="AssetAdministrationShellInterfaceClassLib">
+        <Description>Interface Class Library according to Details of the Asset Administration Shell V2.0.</Description>
+        <Version>1.0.0</Version>
+        <InterfaceClass Name="FileDataReference" RefBaseClassPath="AutomationMLBPRInterfaceClassLib/ExternalDataReference">
+            <Description>A FileDataReference represents the address to a File. FileDataReference is derived from the AutomationML Interface Class ExternalDataReference that is defined in AutomationML BPR_005E_ExternalDataReference_v1.0.0_2:The interface class “ExternalDataReference” shall be used in order to reference external documents out of the scope of AutomationML.</Description>
+        </InterfaceClass>
+        <InterfaceClass Name="ReferableReference" RefBaseClassPath="AutomationMLInterfaceClassLib/AutomationMLBaseInterface">
+            <Description>Reference to any other referable element of the same of any other AAS or a reference to an external object or entity. For local references inside the same Asset Administration Shell an InternalLink between two objects with this interface &quot;ReferableReference&quot; shall be set. In this case the attribute value has to be empty. For references between different Asset Administration Shells or external objects or entities the attribute value shall be used and no InternalLink shall be set.</Description>
+            <Attribute Name="value" AttributeDataType="xs:string">
+                <Description>Reference to any other referable element of any other AAS or a reference to an external object or entity. Note: For references to any other referable element of the same AAS InternalLinks are used and this attribute value shall be empty.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:ReferenceElement/value"/>
+            </Attribute>
+        </InterfaceClass>
+    </InterfaceClassLib>
+    <InterfaceClassLib Name="AutomationMLInterfaceClassLib">
+        <Description>Standard Automation Markup Language Interface Class Library - Part 1 Content extended with Part 3 and Part 4 Content</Description>
+        <Version>2.2.2</Version>
+        <InterfaceClass Name="AutomationMLBaseInterface">
+            <InterfaceClass Name="Order" RefBaseClassPath="AutomationMLBaseInterface">
+                <Attribute Name="Direction" AttributeDataType="xs:string"/>
+            </InterfaceClass>
+            <InterfaceClass Name="PortConnector" RefBaseClassPath="AutomationMLBaseInterface"/>
+            <InterfaceClass Name="InterlockingConnector" RefBaseClassPath="AutomationMLBaseInterface"/>
+            <InterfaceClass Name="PPRConnector" RefBaseClassPath="AutomationMLBaseInterface"/>
+            <InterfaceClass Name="ExternalDataConnector" RefBaseClassPath="AutomationMLBaseInterface">
+                <Attribute Name="refURI" AttributeDataType="xs:anyURI">
+                    <Description>The attribute refURI is an IRI that can represent an absolute or relative path to an L document. An added fragment (with #) references inside the document</Description>
+                </Attribute>
+                <InterfaceClass Name="COLLADAInterface" RefBaseClassPath="ExternalDataConnector">
+                    <Attribute Name="refType" AttributeDataType="xs:string"/>
+                    <Attribute Name="target" AttributeDataType="xs:token"/>
+                </InterfaceClass>
+                <InterfaceClass Name="PLCopenXMLInterface" RefBaseClassPath="ExternalDataConnector">
+                    <InterfaceClass Name="LogicInterface" RefBaseClassPath="PLCopenXMLInterface">
+                        <InterfaceClass Name="SequencingLogicInterface" RefBaseClassPath="AutomationMLInterfaceClassLib/AutomationMLBaseInterface/ExternalDataConnector/PLCopenXMLInterface/LogicInterface"/>
+                        <InterfaceClass Name="BehaviourLogicInterface" RefBaseClassPath="AutomationMLInterfaceClassLib/AutomationMLBaseInterface/ExternalDataConnector/PLCopenXMLInterface/LogicInterface"/>
+                        <InterfaceClass Name="SequencingBehaviourLogicInterface" RefBaseClassPath="AutomationMLInterfaceClassLib/AutomationMLBaseInterface/ExternalDataConnector/PLCopenXMLInterface/LogicInterface"/>
+                        <InterfaceClass Name="InterlockingLogicInterface" RefBaseClassPath="AutomationMLInterfaceClassLib/AutomationMLBaseInterface/ExternalDataConnector/PLCopenXMLInterface/LogicInterface"/>
+                    </InterfaceClass>
+                    <InterfaceClass Name="LogicElementInterface" RefBaseClassPath="PLCopenXMLInterface"/>
+                    <InterfaceClass Name="VariableInterface" RefBaseClassPath="PLCopenXMLInterface">
+                        <InterfaceClass Name="InterlockingVariableInterface" RefBaseClassPath="AutomationMLInterfaceClassLib/AutomationMLBaseInterface/ExternalDataConnector/PLCopenXMLInterface/VariableInterface">
+                            <Attribute Name="SafeConditionEquals" AttributeDataType="xs:boolean">
+                                <DefaultValue>true</DefaultValue>
+                            </Attribute>
+                        </InterfaceClass>
+                    </InterfaceClass>
+                </InterfaceClass>
+            </InterfaceClass>
+            <InterfaceClass Name="Communication" RefBaseClassPath="AutomationMLBaseInterface">
+                <InterfaceClass Name="SignalInterface" RefBaseClassPath="Communication"/>
+            </InterfaceClass>
+            <InterfaceClass Name="AttachmentInterface" RefBaseClassPath="AutomationMLBaseInterface"/>
+        </InterfaceClass>
+    </InterfaceClassLib>
+    <InterfaceClassLib Name="AutomationMLBPRInterfaceClassLib">
+        <Version>1.0.0</Version>
+        <InterfaceClass ID="{320f7f3a-6df8-4ccd-af35-a4367b37eb7a}" Name="ExternalDataReference" RefBaseClassPath="AutomationMLInterfaceClassLib/AutomationMLBaseInterface/ExternalDataConnector">
+            <Attribute Name="MIMEType" AttributeDataType="xs:string">
+                <Description>Mime type of the content of the File.</Description>
+            </Attribute>
+        </InterfaceClass>
+    </InterfaceClassLib>
+    <RoleClassLib Name="AssetAdministrationShellRoleClassLib">
+        <Description>Role Class Library according to Details of the Asset Administration Shell V2.0.</Description>
+        <Version>1.0.0</Version>
+        <RoleClass Name="AssetAdministrationShell" RefBaseClassPath="AutomationMLBaseRoleClassLib/AutomationMLBaseRole">
+            <Description>An Asset Administration Shell.</Description>
+            <Attribute Name="idShort" AttributeDataType="xs:string">
+                <Description>Identifying string of the element within its name space. Constraint AASd-001: In case of a referable element not being an identifiable element this id is mandatory and used for referring to the element in its name space. Constraint AASd-002: idShort shall only feature letters, digits, underscore (&quot;_&quot;); starting mandatory with a letter. Constraint AASd-003: idShort shall be matched case-insensitive. Note: In case of an identifiable element idShort is optional but recommended to be defined. It can be used for unique reference in its name space and thus allows better usability and a more performant implementation. In this case it is similar to the “BrowserPath” in OPC UA.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+            </Attribute>
+            <Attribute Name="category" AttributeDataType="xs:string">
+                <Description>The category is a value that gives further meta information w.r.t. to the class of the element. It affects the expected existence of attributes and the applicability of constraints.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/category"/>
+            </Attribute>
+            <Attribute Name="description" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/description"/>
+                <Attribute Name="aml-lang=EN" AttributeDataType="xs:string">
+                    <Value/>
+                </Attribute>
+                <Attribute Name="aml-lang=DE" AttributeDataType="xs:string">
+                    <Value/>
+                </Attribute>
+            </Attribute>
+            <Attribute Name="identification">
+                <Description>Abstract attribute class for identification. Has the subattributes id and idType.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Identifiable/identification"/>
+                <Attribute Name="id" AttributeDataType="xs:string">
+                    <Description>Identifier of the element. Its type is defined in idType. Id is a subproperty of identification.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Identifier/id"/>
+                </Attribute>
+                <Attribute Name="idType" AttributeDataType="xs:string">
+                    <Description>Type of the Identifier, e.g. IRI, IRDI etc. The supported Identifier types are defined in the enumeration “IdentifierType”. IdType is a subproperty of identification.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Identifier/idType"/>
+                </Attribute>
+            </Attribute>
+            <Attribute Name="administration">
+                <Description>Abstract attribute for administration. Has the subattributes revision and version.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Identifiable/administration"/>
+                <Attribute Name="revision" AttributeDataType="xs:string">
+                    <Description>Revision of the element. Constraint AASd-005: A revision requires a version. This means, if there is no version there is no revision neither. Revision is a subproperty of administration.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:AdministrativeInformation/revision"/>
+                </Attribute>
+                <Attribute Name="version" AttributeDataType="xs:string">
+                    <Description>Version of the element. Version is a subproperty of administration.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:AdministrativeInformation/version"/>
+                </Attribute>
+            </Attribute>
+            <Attribute Name="dataSpecification" AttributeDataType="xs:string">
+                <Description>Global reference to the data specification template used by the element.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:HasDataSpecification/dataSpecification"/>
+            </Attribute>
+            <Attribute Name="derivedFrom" AttributeDataType="xs:string">
+                <Description>The derivedFrom attribute is used to establish a relationship between two Asset Administration Shells that are derived from each other.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:AssetAdministrationShell/derivedFrom"/>
+            </Attribute>
+        </RoleClass>
+        <RoleClass Name="Asset" RefBaseClassPath="AutomationMLBaseRoleClassLib/AutomationMLBaseRole">
+            <Description>An Asset describes meta data of an asset that is represented by an AAS. The asset may either represent an asset type or an asset instance. The asset has a globally unique identifier plus – if needed – additional domain specific (proprietary) identifiers.</Description>
+            <Attribute Name="idShort" AttributeDataType="xs:string">
+                <Description>Identifying string of the element within its name space. Constraint AASd-001: In case of a referable element not being an identifiable element this id is mandatory and used for referring to the element in its name space. Constraint AASd-002: idShort shall only feature letters, digits, underscore (&quot;_&quot;); starting mandatory with a letter. Constraint AASd-003: idShort shall be matched case-insensitive. Note: In case of an identifiable element idShort is optional but recommended to be defined. It can be used for unique reference in its name space and thus allows better usability and a more performant implementation. In this case it is similar to the “BrowserPath” in OPC UA.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+            </Attribute>
+            <Attribute Name="category" AttributeDataType="xs:string">
+                <Description>The category is a value that gives further meta information w.r.t. to the class of the element. It affects the expected existence of attributes and the applicability of constraints.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/category"/>
+            </Attribute>
+            <Attribute Name="description" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/description"/>
+                <Attribute Name="aml-lang=EN"/>
+                <Attribute Name="aml-lang=DE"/>
+            </Attribute>
+            <Attribute Name="identification">
+                <Description>Abstract attribute class for identification. Has the subattributes id and idType.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Identifiable/identification"/>
+                <Attribute Name="id" AttributeDataType="xs:string">
+                    <Description>Identifier of the element. Its type is defined in idType.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Identifier/id"/>
+                </Attribute>
+                <Attribute Name="idType" AttributeDataType="xs:string">
+                    <Description>Type of the Identifier, e.g. IRI, IRDI etc. The supported Identifier types are defined in the enumeration “IdentifierType”. IdType is a subproperty of identification.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Identifier/idType"/>
+                </Attribute>
+            </Attribute>
+            <Attribute Name="administration">
+                <Description>Abstract attribute for administration. Has the subattributes revision and version.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Identifiable/administration"/>
+                <Attribute Name="revision" AttributeDataType="xs:string">
+                    <Description>Revision of the element. Constraint AASd-005: A revision requires a version. This means, if there is no version there is no revision neither. Revision is a subproperty of administration.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:AdministrativeInformation/revision"/>
+                </Attribute>
+                <Attribute Name="version" AttributeDataType="xs:string">
+                    <Description>Version of the element. Version is a subproperty of administration.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:AdministrativeInformation/version"/>
+                </Attribute>
+            </Attribute>
+            <Attribute Name="dataSpecification" AttributeDataType="xs:string">
+                <Description>Global reference to the data specification template used by the element.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:HasDataSpecification/dataSpecification"/>
+            </Attribute>
+            <Attribute Name="kind" AttributeDataType="xs:string">
+                <Description>Kind of the asset: either type or instance.</Description>
+                <DefaultValue>Instance</DefaultValue>
+                <Value>Instance</Value>
+                <RefSemantic CorrespondingAttributePath="AAS:Asset/kind"/>
+                <Constraint Name="">
+                    <NominalScaledType>
+                        <RequiredValue>Instance</RequiredValue>
+                        <RequiredValue>Type</RequiredValue>
+                    </NominalScaledType>
+                </Constraint>
+            </Attribute>
+        </RoleClass>
+        <RoleClass Name="Submodel" RefBaseClassPath="AutomationMLBaseRoleClassLib/AutomationMLBaseRole">
+            <Description>A Submodel defines a specific aspect of the asset represented by the AAS. A submodel is used to structure the virtual representation and technical functionality of an Administration Shell into distinguishable parts. Each submodel refers to a well-defined domain or subject matter. Submodels can become standardized and thus become submodels types. Submodels can have different life-cycles.</Description>
+            <Attribute Name="idShort" AttributeDataType="xs:string">
+                <Description>Identifying string of the element within its name space. Constraint AASd-001: In case of a referable element not being an identifiable element this id is mandatory and used for referring to the element in its name space. Constraint AASd-002: idShort shall only feature letters, digits, underscore (&quot;_&quot;); starting mandatory with a letter. Constraint AASd-003: idShort shall be matched case-insensitive. Note: In case of an identifiable element idShort is optional but recommended to be defined. It can be used for unique reference in its name space and thus allows better usability and a more performant implementation. In this case it is similar to the “BrowserPath” in OPC UA.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+            </Attribute>
+            <Attribute Name="category" AttributeDataType="xs:string">
+                <Description>The category is a value that gives further meta information w.r.t. to the class of the element. It affects the expected existence of attributes and the applicability of constraints.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/category"/>
+            </Attribute>
+            <Attribute Name="description" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/description"/>
+                <Attribute Name="aml-lang=EN"/>
+                <Attribute Name="aml-lang=DE"/>
+            </Attribute>
+            <Attribute Name="identification">
+                <Description>Abstract attribute class for identification. Has the subattributes id and idType.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Identifiable/identification"/>
+                <Attribute Name="id" AttributeDataType="xs:string">
+                    <Description>Identifier of the element. Its type is defined in idType. Id is a subproperty of identification.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Identifier/id"/>
+                </Attribute>
+                <Attribute Name="idType">
+                    <Description>Type of the Identifier, e.g. IRI, IRDI etc. The supported Identifier types are defined in the enumeration “IdentifierType”. IdType is a subproperty of identification.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Identifier/idType"/>
+                </Attribute>
+            </Attribute>
+            <Attribute Name="administration">
+                <Description>Abstract attribute for administration. Has the subattributes revision and version.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Identifiable/administration"/>
+                <Attribute Name="revision" AttributeDataType="xs:string">
+                    <Description>Revision of the element. Constraint AASd-005: A revision requires a version. This means, if there is no version there is no revision neither. Revision is a subproperty of administration.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:AdministrativeInformation/revision"/>
+                </Attribute>
+                <Attribute Name="version" AttributeDataType="xs:string">
+                    <Description>Version of the element. Version of the element. Version is a subproperty of administration.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:AdministrativeInformation/version"/>
+                </Attribute>
+            </Attribute>
+            <Attribute Name="dataSpecification" AttributeDataType="xs:string">
+                <Description>Global reference to the data specification template used by the element.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:HasDataSpecification/dataSpecification"/>
+            </Attribute>
+            <Attribute Name="kind" AttributeDataType="xs:string">
+                <Description>Kind of the element: either template or instance.</Description>
+                <DefaultValue>Instance</DefaultValue>
+                <Value>Instance</Value>
+                <RefSemantic CorrespondingAttributePath="AAS:HasKind/kind"/>
+                <Constraint Name="">
+                    <NominalScaledType>
+                        <RequiredValue>Instance</RequiredValue>
+                        <RequiredValue>Type</RequiredValue>
+                    </NominalScaledType>
+                </Constraint>
+            </Attribute>
+            <Attribute Name="semanticId" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages. This attribute has the name of the label and has a value with the label written in the default language. The individual languages are modelled as child attributes. The names of the child attributes are the prefix “aml-lang=” with the expression of the language in compliance with RFC5646. At it, the values of the child attributes are the labels within the respective language.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:HasSemantics/semanticId"/>
+            </Attribute>
+            <Attribute Name="qualifier:[TYPE]=[VALUE]" AttributeDataType="xs:string">
+                <Description>A qualifier is a type-value-pair that makes additional statements w.r.t. the value of the element. [TYPE] is the value of the attribute type and [VALUE] is the value of the attribute value.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Qualifiable/qualifier"/>
+                <Attribute Name="type" AttributeDataType="xs:string">
+                    <Description>The type describes the type of the qualifier that is applied to the element.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/type"/>
+                </Attribute>
+                <Attribute Name="value" AttributeDataType="xs:string">
+                    <Description>The qualifier value is the value of the qualifier. Constraint AASd-006: if both, the value and the valueId are present then the value needs to be identical to the value of the referenced coded value in valueId.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/value"/>
+                </Attribute>
+                <Attribute Name="valueId" AttributeDataType="xs:string">
+                    <Description>Reference to the global unqiue id of a coded value.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/valueId"/>
+                </Attribute>
+            </Attribute>
+        </RoleClass>
+        <RoleClass Name="SubmodelElementCollection" RefBaseClassPath="AutomationMLBaseRoleClassLib/AutomationMLBaseRole">
+            <Description>A submodel element collection is a set or list of submodel elements.</Description>
+            <Attribute Name="idShort" AttributeDataType="xs:string">
+                <Description>Identifying string of the element within its name space. Constraint AASd-001: In case of a referable element not being an identifiable element this id is mandatory and used for referring to the element in its name space. Constraint AASd-002: idShort shall only feature letters, digits, underscore (&quot;_&quot;); starting mandatory with a letter. Constraint AASd-003: idShort shall be matched case-insensitive. Note: In case of an identifiable element idShort is optional but recommended to be defined. It can be used for unique reference in its name space and thus allows better usability and a more performant implementation. In this case it is similar to the “BrowserPath” in OPC UA.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+            </Attribute>
+            <Attribute Name="category" AttributeDataType="xs:string">
+                <Description>The category is a value that gives further meta information w.r.t. to the class of the element. It affects the expected existence of attributes and the applicability of constraints.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/category"/>
+            </Attribute>
+            <Attribute Name="description" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/description"/>
+                <Attribute Name="aml-lang=EN"/>
+                <Attribute Name="aml-lang=DE"/>
+            </Attribute>
+            <Attribute Name="dataSpecification" AttributeDataType="xs:string">
+                <Description>Global reference to the data specification template used by the element.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:HasDataSpecification/dataSpecification"/>
+            </Attribute>
+            <Attribute Name="kind" AttributeDataType="xs:string">
+                <Description>Kind of the element: either template or instance.</Description>
+                <DefaultValue>Instance</DefaultValue>
+                <Value>Instance</Value>
+                <RefSemantic CorrespondingAttributePath="AAS:HasKind/kind"/>
+                <Constraint Name="">
+                    <NominalScaledType>
+                        <RequiredValue>Instance</RequiredValue>
+                        <RequiredValue>Type</RequiredValue>
+                    </NominalScaledType>
+                </Constraint>
+            </Attribute>
+            <Attribute Name="semanticId" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages. This attribute has the name of the label and has a value with the label written in the default language. The individual languages are modelled as child attributes. The names of the child attributes are the prefix “aml-lang=” with the expression of the language in compliance with RFC5646. At it, the values of the child attributes are the labels within the respective language.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:HasSemantics/semanticId"/>
+            </Attribute>
+            <Attribute Name="qualifier:[TYPE]=[VALUE]" AttributeDataType="xs:string">
+                <Description>A qualifier is a type-value-pair that makes additional statements w.r.t. the value of the element. [TYPE] is the value of the attribute type and [VALUE] is the value of the attribute value.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Qualifiable/qualifier"/>
+                <Attribute Name="type" AttributeDataType="xs:string">
+                    <Description>The type describes the type of the qualifier that is applied to the element.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/type"/>
+                </Attribute>
+                <Attribute Name="value" AttributeDataType="xs:string">
+                    <Description>The qualifier value is the value of the qualifier. Constraint AASd-006: if both, the value and the valueId are present then the value needs to be identical to the value of the referenced coded value in valueId.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/value"/>
+                </Attribute>
+                <Attribute Name="valueId" AttributeDataType="xs:string">
+                    <Description>Reference to the global unqiue id of a coded value.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/valueId"/>
+                </Attribute>
+            </Attribute>
+            <Attribute Name="allowDuplicates" AttributeDataType="xs:boolean">
+                <Description>If allowDuplicates=true, then it is allowed that the collection contains the same element several times.</Description>
+                <DefaultValue>false</DefaultValue>
+                <RefSemantic CorrespondingAttributePath="AAS:SubmodulElementCollection/allowDuplicates"/>
+            </Attribute>
+            <Attribute Name="ordered" AttributeDataType="xs:boolean">
+                <Description>If ordered=false, then the elements in the property collection are not ordered. If ordered=true then the elements in the collection are ordered. Default = false. Note: An ordered submodel element collection is typically implemented as an indexed array.</Description>
+                <DefaultValue>false</DefaultValue>
+                <RefSemantic CorrespondingAttributePath="AAS:SubmodulElementCollection/ordered"/>
+            </Attribute>
+            <Attribute Name="value" AttributeDataType="xs:string">
+                <Description>Submodel element contained in the collection.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:SubmodulElementCollection/value"/>
+            </Attribute>
+        </RoleClass>
+        <RoleClass Name="Blob" RefBaseClassPath="AutomationMLBaseRoleClassLib/AutomationMLBaseRole">
+            <Description>A BLOB is a data element that represents a file that is contained with its source code in the value attribute.</Description>
+            <Attribute Name="idShort" AttributeDataType="xs:string">
+                <Description>Identifying string of the element within its name space. Constraint AASd-001: In case of a referable element not being an identifiable element this id is mandatory and used for referring to the element in its name space. Constraint AASd-002: idShort shall only feature letters, digits, underscore (&quot;_&quot;); starting mandatory with a letter. Constraint AASd-003: idShort shall be matched case-insensitive. Note: In case of an identifiable element idShort is optional but recommended to be defined. It can be used for unique reference in its name space and thus allows better usability and a more performant implementation. In this case it is similar to the “BrowserPath” in OPC UA.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+            </Attribute>
+            <Attribute Name="category" AttributeDataType="xs:string">
+                <Description>The category is a value that gives further meta information w.r.t. to the class of the element. It affects the expected existence of attributes and the applicability of constraints.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/category"/>
+            </Attribute>
+            <Attribute Name="description" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/description"/>
+                <Attribute Name="aml-lang=EN"/>
+                <Attribute Name="aml-lang=DE"/>
+            </Attribute>
+            <Attribute Name="dataSpecification" AttributeDataType="xs:string">
+                <Description>Global reference to the data specification template used by the element.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:HasDataSpecification/dataSpecification"/>
+            </Attribute>
+            <Attribute Name="kind" AttributeDataType="xs:string">
+                <Description>Kind of the element: either template or instance.</Description>
+                <DefaultValue>Instance</DefaultValue>
+                <Value>Instance</Value>
+                <RefSemantic CorrespondingAttributePath="AAS:HasKind/kind"/>
+                <Constraint Name="">
+                    <NominalScaledType>
+                        <RequiredValue>Instance</RequiredValue>
+                        <RequiredValue>Type</RequiredValue>
+                    </NominalScaledType>
+                </Constraint>
+            </Attribute>
+            <Attribute Name="semanticId" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages. This attribute has the name of the label and has a value with the label written in the default language. The individual languages are modelled as child attributes. The names of the child attributes are the prefix “aml-lang=” with the expression of the language in compliance with RFC5646. At it, the values of the child attributes are the labels within the respective language.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:HasSemantics/semanticId"/>
+            </Attribute>
+            <Attribute Name="qualifier:[TYPE]=[VALUE]" AttributeDataType="xs:string">
+                <Description>A qualifier is a type-value-pair that makes additional statements w.r.t. the value of the element. [TYPE] is the value of the attribute type and [VALUE] is the value of the attribute value.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Qualifiable/qualifier"/>
+                <Attribute Name="type" AttributeDataType="xs:string">
+                    <Description>The type describes the type of the qualifier that is applied to the element.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/type"/>
+                </Attribute>
+                <Attribute Name="value" AttributeDataType="xs:string">
+                    <Description>The qualifier value is the value of the qualifier. Constraint AASd-006: if both, the value and the valueId are present then the value needs to be identical to the value of the referenced coded value in valueId.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/value"/>
+                </Attribute>
+                <Attribute Name="valueId" AttributeDataType="xs:string">
+                    <Description>Reference to the global unqiue id of a coded value.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/valueId"/>
+                </Attribute>
+            </Attribute>
+            <Attribute Name="mimeType" AttributeDataType="xs:string">
+                <Description>Mime type of the content of the BLOB. The mime type states which file extension the file has. Valid values are e.g. “application/json”, “application/xls”, ”image/jpg”. The allowed values are defined as in RFC2046.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:Blob/mimeType"/>
+            </Attribute>
+            <Attribute Name="value" AttributeDataType="xs:string">
+                <Description>The value of the BLOB instance of a blob data element. Note: In contrast to the file property the file content is stored directly as value in the Blob data element.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:Blob/value"/>
+            </Attribute>
+        </RoleClass>
+        <RoleClass Name="Capability" RefBaseClassPath="AutomationMLBaseRoleClassLib/AutomationMLBaseRole">
+            <Description>A capability is the implementation-independent description of the potential of an asset to achieve a certain effect in the physical or virtual world.</Description>
+            <Attribute Name="idShort" AttributeDataType="xs:string">
+                <Description>Identifying string of the element within its name space. Constraint AASd-001: In case of a referable element not being an identifiable element this id is mandatory and used for referring to the element in its name space. Constraint AASd-002: idShort shall only feature letters, digits, underscore (&quot;_&quot;); starting mandatory with a letter. Constraint AASd-003: idShort shall be matched case-insensitive. Note: In case of an identifiable element idShort is optional but recommended to be defined. It can be used for unique reference in its name space and thus allows better usability and a more performant implementation. In this case it is similar to the “BrowserPath” in OPC UA.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+            </Attribute>
+            <Attribute Name="category" AttributeDataType="xs:string">
+                <Description>The category is a value that gives further meta information w.r.t. to the class of the element. It affects the expected existence of attributes and the applicability of constraints.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/category"/>
+            </Attribute>
+            <Attribute Name="description" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/description"/>
+                <Attribute Name="aml-lang=EN"/>
+                <Attribute Name="aml-lang=DE"/>
+            </Attribute>
+            <Attribute Name="dataSpecification" AttributeDataType="xs:string">
+                <Description>Global reference to the data specification template used by the element.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:HasDataSpecification/dataSpecification"/>
+            </Attribute>
+            <Attribute Name="kind" AttributeDataType="xs:string">
+                <Description>Kind of the element: either template or instance.</Description>
+                <DefaultValue>Instance</DefaultValue>
+                <Value>Instance</Value>
+                <RefSemantic CorrespondingAttributePath="AAS:HasKind/kind"/>
+                <Constraint Name="">
+                    <NominalScaledType>
+                        <RequiredValue>Instance</RequiredValue>
+                        <RequiredValue>Type</RequiredValue>
+                    </NominalScaledType>
+                </Constraint>
+            </Attribute>
+            <Attribute Name="semanticId" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages. This attribute has the name of the label and has a value with the label written in the default language. The individual languages are modelled as child attributes. The names of the child attributes are the prefix “aml-lang=” with the expression of the language in compliance with RFC5646. At it, the values of the child attributes are the labels within the respective language.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:HasSemantics/semanticId"/>
+            </Attribute>
+            <Attribute Name="qualifier:[TYPE]=[VALUE]" AttributeDataType="xs:string">
+                <Description>A qualifier is a type-value-pair that makes additional statements w.r.t. the value of the element. [TYPE] is the value of the attribute type and [VALUE] is the value of the attribute value.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Qualifiable/qualifier"/>
+                <Attribute Name="type" AttributeDataType="xs:string">
+                    <Description>The type describes the type of the qualifier that is applied to the element.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/type"/>
+                </Attribute>
+                <Attribute Name="value" AttributeDataType="xs:string">
+                    <Description>The qualifier value is the value of the qualifier. Constraint AASd-006: if both, the value and the valueId are present then the value needs to be identical to the value of the referenced coded value in valueId.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/value"/>
+                </Attribute>
+                <Attribute Name="valueId" AttributeDataType="xs:string">
+                    <Description>Reference to the global unqiue id of a coded value.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/valueId"/>
+                </Attribute>
+            </Attribute>
+        </RoleClass>
+        <RoleClass Name="File" RefBaseClassPath="AutomationMLBPRRoleClassLib/ExternalData">
+            <Description>A role class for a File that a data element that represents an address to a file. It is derived from the AutomationML role class ExternalData that is an role type for a document type and the base class for all document type roles. It describes different document types. ExternalData is defined in AutomationML BPR_005E_ExternalDataReference_v1.0.0_2.</Description>
+            <Attribute Name="idShort" AttributeDataType="xs:string">
+                <Description>Identifying string of the element within its name space. Constraint AASd-001: In case of a referable element not being an identifiable element this id is mandatory and used for referring to the element in its name space. Constraint AASd-002: idShort shall only feature letters, digits, underscore (&quot;_&quot;); starting mandatory with a letter. Constraint AASd-003: idShort shall be matched case-insensitive. Note: In case of an identifiable element idShort is optional but recommended to be defined. It can be used for unique reference in its name space and thus allows better usability and a more performant implementation. In this case it is similar to the “BrowserPath” in OPC UA.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+            </Attribute>
+            <Attribute Name="category" AttributeDataType="xs:string">
+                <Description>The category is a value that gives further meta information w.r.t. to the class of the element. It affects the expected existence of attributes and the applicability of constraints.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/category"/>
+            </Attribute>
+            <Attribute Name="description" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/description"/>
+                <Attribute Name="aml-lang=EN"/>
+                <Attribute Name="aml-lang=DE"/>
+            </Attribute>
+            <Attribute Name="dataSpecification" AttributeDataType="xs:string">
+                <Description>Global reference to the data specification template used by the element.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:HasDataSpecification/dataSpecification"/>
+            </Attribute>
+            <Attribute Name="kind" AttributeDataType="xs:string">
+                <Description>Kind of the element: either template or instance.</Description>
+                <DefaultValue>Instance</DefaultValue>
+                <Value>Instance</Value>
+                <RefSemantic CorrespondingAttributePath="AAS:HasKind/kind"/>
+                <Constraint Name="">
+                    <NominalScaledType>
+                        <RequiredValue>Instance</RequiredValue>
+                        <RequiredValue>Type</RequiredValue>
+                    </NominalScaledType>
+                </Constraint>
+            </Attribute>
+            <Attribute Name="semanticId" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages. This attribute has the name of the label and has a value with the label written in the default language. The individual languages are modelled as child attributes. The names of the child attributes are the prefix “aml-lang=” with the expression of the language in compliance with RFC5646. At it, the values of the child attributes are the labels within the respective language.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:HasSemantics/semanticId"/>
+            </Attribute>
+            <Attribute Name="qualifier:[TYPE]=[VALUE]" AttributeDataType="xs:string">
+                <Description>A qualifier is a type-value-pair that makes additional statements w.r.t. the value of the element. [TYPE] is the value of the attribute type and [VALUE] is the value of the attribute value.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Qualifiable/qualifier"/>
+                <Attribute Name="type" AttributeDataType="xs:string">
+                    <Description>The type describes the type of the qualifier that is applied to the element.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/type"/>
+                </Attribute>
+                <Attribute Name="value" AttributeDataType="xs:string">
+                    <Description>The qualifier value is the value of the qualifier. Constraint AASd-006: if both, the value and the valueId are present then the value needs to be identical to the value of the referenced coded value in valueId.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/value"/>
+                </Attribute>
+                <Attribute Name="valueId" AttributeDataType="xs:string">
+                    <Description>Reference to the global unqiue id of a coded value.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/valueId"/>
+                </Attribute>
+            </Attribute>
+            <ExternalInterface ID="c7a2932e-7f90-46d3-be64-0408a927c89d" Name="FileDataReference" RefBaseClassPath="AssetAdministrationShellInterfaceClassLib/FileDataReference">
+                <Attribute Name="refURI" AttributeDataType="xs:anyURI">
+                    <Description>The attribute refURI is an IRI that can represent an absolute or relative path to an L document. An added fragment (with #) references inside the document</Description>
+                </Attribute>
+                <Attribute Name="MIMEType" AttributeDataType="xs:string">
+                    <Description>Mime type of the content of the File.</Description>
+                </Attribute>
+            </ExternalInterface>
+        </RoleClass>
+        <RoleClass Name="Property" RefBaseClassPath="AutomationMLBaseRoleClassLib/AutomationMLBaseRole">
+            <Description>A property is a data element that has a single value.</Description>
+            <Attribute Name="idShort" AttributeDataType="xs:string">
+                <Description>Identifying string of the element within its name space. Constraint AASd-001: In case of a referable element not being an identifiable element this id is mandatory and used for referring to the element in its name space. Constraint AASd-002: idShort shall only feature letters, digits, underscore (&quot;_&quot;); starting mandatory with a letter. Constraint AASd-003: idShort shall be matched case-insensitive. Note: In case of an identifiable element idShort is optional but recommended to be defined. It can be used for unique reference in its name space and thus allows better usability and a more performant implementation. In this case it is similar to the “BrowserPath” in OPC UA.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+            </Attribute>
+            <Attribute Name="category" AttributeDataType="xs:string">
+                <Description>The category is a value that gives further meta information w.r.t. to the class of the element. It affects the expected existence of attributes and the applicability of constraints.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/category"/>
+            </Attribute>
+            <Attribute Name="description" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/description"/>
+                <Attribute Name="aml-lang=EN"/>
+                <Attribute Name="aml-lang=DE"/>
+            </Attribute>
+            <Attribute Name="dataSpecification" AttributeDataType="xs:string">
+                <Description>Global reference to the data specification template used by the element.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:HasDataSpecification/dataSpecification"/>
+            </Attribute>
+            <Attribute Name="kind" AttributeDataType="xs:string">
+                <Description>Kind of the element: either template or instance.</Description>
+                <DefaultValue>Instance</DefaultValue>
+                <Value>Instance</Value>
+                <RefSemantic CorrespondingAttributePath="AAS:HasKind/kind"/>
+                <Constraint Name="">
+                    <NominalScaledType>
+                        <RequiredValue>Instance</RequiredValue>
+                        <RequiredValue>Type</RequiredValue>
+                    </NominalScaledType>
+                </Constraint>
+            </Attribute>
+            <Attribute Name="semanticId" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages. This attribute has the name of the label and has a value with the label written in the default language. The individual languages are modelled as child attributes. The names of the child attributes are the prefix “aml-lang=” with the expression of the language in compliance with RFC5646. At it, the values of the child attributes are the labels within the respective language.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:HasSemantics/semanticId"/>
+            </Attribute>
+            <Attribute Name="qualifier:[TYPE]=[VALUE]" AttributeDataType="xs:string">
+                <Description>A qualifier is a type-value-pair that makes additional statements w.r.t. the value of the element. [TYPE] is the value of the attribute type and [VALUE] is the value of the attribute value.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Qualifiable/qualifier"/>
+                <Attribute Name="type" AttributeDataType="xs:string">
+                    <Description>The type describes the type of the qualifier that is applied to the element.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/type"/>
+                </Attribute>
+                <Attribute Name="value" AttributeDataType="xs:string">
+                    <Description>The qualifier value is the value of the qualifier. Constraint AASd-006: if both, the value and the valueId are present then the value needs to be identical to the value of the referenced coded value in valueId.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/value"/>
+                </Attribute>
+                <Attribute Name="valueId" AttributeDataType="xs:string">
+                    <Description>Reference to the global unqiue id of a coded value.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/valueId"/>
+                </Attribute>
+            </Attribute>
+            <Attribute Name="value" AttributeDataType="xs:string">
+                <Description>The value of the property instance.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Property/value"/>
+            </Attribute>
+            <Attribute Name="valueId" AttributeDataType="xs:string">
+                <Description>Reference to the global unique id if a coded value.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Property/valueId"/>
+            </Attribute>
+        </RoleClass>
+        <RoleClass Name="ReferenceElement" RefBaseClassPath="AutomationMLBaseRoleClassLib/AutomationMLBaseRole">
+            <Description>A reference element is a data element that defines a logical reference to another element within the same or another AAS or a reference to an external object or entity.</Description>
+            <Attribute Name="idShort" AttributeDataType="xs:string">
+                <Description>Identifying string of the element within its name space. Constraint AASd-001: In case of a referable element not being an identifiable element this id is mandatory and used for referring to the element in its name space. Constraint AASd-002: idShort shall only feature letters, digits, underscore (&quot;_&quot;); starting mandatory with a letter. Constraint AASd-003: idShort shall be matched case-insensitive. Note: In case of an identifiable element idShort is optional but recommended to be defined. It can be used for unique reference in its name space and thus allows better usability and a more performant implementation. In this case it is similar to the “BrowserPath” in OPC UA.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+            </Attribute>
+            <Attribute Name="category" AttributeDataType="xs:string">
+                <Description>The category is a value that gives further meta information w.r.t. to the class of the element. It affects the expected existence of attributes and the applicability of constraints.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/category"/>
+            </Attribute>
+            <Attribute Name="description" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/description"/>
+                <Attribute Name="aml-lang=EN"/>
+                <Attribute Name="aml-lang=DE"/>
+            </Attribute>
+            <Attribute Name="dataSpecification" AttributeDataType="xs:string">
+                <Description>Global reference to the data specification template used by the element.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:HasDataSpecification/dataSpecification"/>
+            </Attribute>
+            <Attribute Name="kind" AttributeDataType="xs:string">
+                <Description>Kind of the element: either template or instance.</Description>
+                <DefaultValue>Instance</DefaultValue>
+                <Value>Instance</Value>
+                <RefSemantic CorrespondingAttributePath="AAS:HasKind/kind"/>
+                <Constraint Name="">
+                    <NominalScaledType>
+                        <RequiredValue>Instance</RequiredValue>
+                        <RequiredValue>Type</RequiredValue>
+                    </NominalScaledType>
+                </Constraint>
+            </Attribute>
+            <Attribute Name="semanticId" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages. This attribute has the name of the label and has a value with the label written in the default language. The individual languages are modelled as child attributes. The names of the child attributes are the prefix “aml-lang=” with the expression of the language in compliance with RFC5646. At it, the values of the child attributes are the labels within the respective language.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:HasSemantics/semanticId"/>
+            </Attribute>
+            <Attribute Name="qualifier:[TYPE]=[VALUE]" AttributeDataType="xs:string">
+                <Description>A qualifier is a type-value-pair that makes additional statements w.r.t. the value of the element. [TYPE] is the value of the attribute type and [VALUE] is the value of the attribute value.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Qualifiable/qualifier"/>
+                <Attribute Name="type" AttributeDataType="xs:string">
+                    <Description>The type describes the type of the qualifier that is applied to the element.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/type"/>
+                </Attribute>
+                <Attribute Name="value" AttributeDataType="xs:string">
+                    <Description>The qualifier value is the value of the qualifier. Constraint AASd-006: if both, the value and the valueId are present then the value needs to be identical to the value of the referenced coded value in valueId.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/value"/>
+                </Attribute>
+                <Attribute Name="valueId" AttributeDataType="xs:string">
+                    <Description>Reference to the global unqiue id of a coded value.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/valueId"/>
+                </Attribute>
+            </Attribute>
+            <ExternalInterface ID="cedd4784-8dd9-4b0d-bb16-59a82ab845da" Name="ReferableReference" RefBaseClassPath="AssetAdministrationShellInterfaceClassLib/ReferableReference">
+                <Attribute Name="value" AttributeDataType="xs:string">
+                    <Description>Reference to any other referable element of any other AAS or a reference to an external object or entity. Note: For references to any other referable elment of the same AAS InternalLinks are used and this attribute value shall be empty.</Description>
+                    <RefSemantic CorrespondingAttributePath="AAS:ReferenceElement/value"/>
+                </Attribute>
+            </ExternalInterface>
+        </RoleClass>
+        <RoleClass Name="RelationshipElement" RefBaseClassPath="AutomationMLBaseRoleClassLib/AutomationMLBaseRole">
+            <Description>A relationship element is used to define a relationship between two referable elements.</Description>
+            <Attribute Name="idShort" AttributeDataType="xs:string">
+                <Description>Identifying string of the element within its name space. Constraint AASd-001: In case of a referable element not being an identifiable element this id is mandatory and used for referring to the element in its name space. Constraint AASd-002: idShort shall only feature letters, digits, underscore (&quot;_&quot;); starting mandatory with a letter. Constraint AASd-003: idShort shall be matched case-insensitive. Note: In case of an identifiable element idShort is optional but recommended to be defined. It can be used for unique reference in its name space and thus allows better usability and a more performant implementation. In this case it is similar to the “BrowserPath” in OPC UA.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+            </Attribute>
+            <Attribute Name="category" AttributeDataType="xs:string">
+                <Description>The category is a value that gives further meta information w.r.t. to the class of the element. It affects the expected existence of attributes and the applicability of constraints.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/category"/>
+            </Attribute>
+            <Attribute Name="description" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/description"/>
+                <Attribute Name="aml-lang=EN"/>
+                <Attribute Name="aml-lang=DE"/>
+            </Attribute>
+            <Attribute Name="dataSpecification" AttributeDataType="xs:string">
+                <Description>Global reference to the data specification template used by the element.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:HasDataSpecification/dataSpecification"/>
+            </Attribute>
+            <Attribute Name="kind" AttributeDataType="xs:string">
+                <Description>Kind of the element: either template or instance.</Description>
+                <DefaultValue>Instance</DefaultValue>
+                <Value>Instance</Value>
+                <RefSemantic CorrespondingAttributePath="AAS:HasKind/kind"/>
+                <Constraint Name="">
+                    <NominalScaledType>
+                        <RequiredValue>Instance</RequiredValue>
+                        <RequiredValue>Type</RequiredValue>
+                    </NominalScaledType>
+                </Constraint>
+            </Attribute>
+            <Attribute Name="semanticId" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages. This attribute has the name of the label and has a value with the label written in the default language. The individual languages are modelled as child attributes. The names of the child attributes are the prefix “aml-lang=” with the expression of the language in compliance with RFC5646. At it, the values of the child attributes are the labels within the respective language.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:HasSemantics/semanticId"/>
+            </Attribute>
+            <Attribute Name="qualifier:[TYPE]=[VALUE]" AttributeDataType="xs:string">
+                <Description>A qualifier is a type-value-pair that makes additional statements w.r.t. the value of the element. [TYPE] is the value of the attribute type and [VALUE] is the value of the attribute value.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Qualifiable/qualifier"/>
+                <Attribute Name="type" AttributeDataType="xs:string">
+                    <Description>The type describes the type of the qualifier that is applied to the element.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/type"/>
+                </Attribute>
+                <Attribute Name="value" AttributeDataType="xs:string">
+                    <Description>The qualifier value is the value of the qualifier. Constraint AASd-006: if both, the value and the valueId are present then the value needs to be identical to the value of the referenced coded value in valueId.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/value"/>
+                </Attribute>
+                <Attribute Name="valueId" AttributeDataType="xs:string">
+                    <Description>Reference to the global unqiue id of a coded value.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/valueId"/>
+                </Attribute>
+            </Attribute>
+            <ExternalInterface ID="6382c562-f165-488c-94c6-52fe0b27bb6a" Name="first" RefBaseClassPath="AssetAdministrationShellInterfaceClassLib/ReferableReference">
+                <Attribute Name="value" AttributeDataType="xs:string">
+                    <Description>Reference to any other referable element of any other AAS or a reference to an external object or entity. Note: For references to any other referable elment of the same AAS InternalLinks are used and this attribute value shall be empty.</Description>
+                </Attribute>
+            </ExternalInterface>
+            <ExternalInterface ID="f05eccaf-f1f7-4c0c-8502-ba5372640814" Name="second" RefBaseClassPath="AssetAdministrationShellInterfaceClassLib/ReferableReference">
+                <Attribute Name="value" AttributeDataType="xs:string">
+                    <Description>Reference to any other referable element of any other AAS or a reference to an external object or entity. Note: For references to any other referable elment of the same AAS InternalLinks are used and this attribute value shall be empty.</Description>
+                </Attribute>
+            </ExternalInterface>
+        </RoleClass>
+        <RoleClass Name="AnnotatedRelationshipElement" RefBaseClassPath="AssetAdministrationShellRoleClassLib/RelationshipElement">
+            <Description>An annotated relationship element is an relationship element that can be annotated with additional data elements.</Description>
+            <Attribute Name="annotation" AttributeDataType="xs:string">
+                <Description>Annotations that hold for the relationships between the two elements.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:AnnotatedRelationshipElement/annotation"/>
+            </Attribute>
+        </RoleClass>
+        <RoleClass Name="Operation" RefBaseClassPath="AutomationMLBaseRoleClassLib/AutomationMLBaseRole">
+            <Description>An operation is a submodel element with input and output variables.</Description>
+            <Attribute Name="idShort" AttributeDataType="xs:string">
+                <Description>Identifying string of the element within its name space. Constraint AASd-001: In case of a referable element not being an identifiable element this id is mandatory and used for referring to the element in its name space. Constraint AASd-002: idShort shall only feature letters, digits, underscore (&quot;_&quot;); starting mandatory with a letter. Constraint AASd-003: idShort shall be matched case-insensitive. Note: In case of an identifiable element idShort is optional but recommended to be defined. It can be used for unique reference in its name space and thus allows better usability and a more performant implementation. In this case it is similar to the “BrowserPath” in OPC UA.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+            </Attribute>
+            <Attribute Name="category" AttributeDataType="xs:string">
+                <Description>The category is a value that gives further meta information w.r.t. to the class of the element. It affects the expected existence of attributes and the applicability of constraints.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/category"/>
+            </Attribute>
+            <Attribute Name="description" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/description"/>
+                <Attribute Name="aml-lang=EN"/>
+                <Attribute Name="aml-lang=DE"/>
+            </Attribute>
+            <Attribute Name="dataSpecification" AttributeDataType="xs:string">
+                <Description>Global reference to the data specification template used by the element.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:HasDataSpecification/dataSpecification"/>
+            </Attribute>
+            <Attribute Name="kind" AttributeDataType="xs:string">
+                <Description>Kind of the element: either template or instance.</Description>
+                <DefaultValue>Instance</DefaultValue>
+                <Value>Instance</Value>
+                <RefSemantic CorrespondingAttributePath="AAS:HasKind/kind"/>
+                <Constraint Name="">
+                    <NominalScaledType>
+                        <RequiredValue>Instance</RequiredValue>
+                        <RequiredValue>Type</RequiredValue>
+                    </NominalScaledType>
+                </Constraint>
+            </Attribute>
+            <Attribute Name="semanticId" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages. This attribute has the name of the label and has a value with the label written in the default language. The individual languages are modelled as child attributes. The names of the child attributes are the prefix “aml-lang=” with the expression of the language in compliance with RFC5646. At it, the values of the child attributes are the labels within the respective language.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:HasSemantics/semanticId"/>
+            </Attribute>
+            <Attribute Name="qualifier:[TYPE]=[VALUE]" AttributeDataType="xs:string">
+                <Description>A qualifier is a type-value-pair that makes additional statements w.r.t. the value of the element. [TYPE] is the value of the attribute type and [VALUE] is the value of the attribute value.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Qualifiable/qualifier"/>
+                <Attribute Name="type" AttributeDataType="xs:string">
+                    <Description>The type describes the type of the qualifier that is applied to the element.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/type"/>
+                </Attribute>
+                <Attribute Name="value" AttributeDataType="xs:string">
+                    <Description>The qualifier value is the value of the qualifier. Constraint AASd-006: if both, the value and the valueId are present then the value needs to be identical to the value of the referenced coded value in valueId.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/value"/>
+                </Attribute>
+                <Attribute Name="valueId" AttributeDataType="xs:string">
+                    <Description>Reference to the global unqiue id of a coded value.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/valueId"/>
+                </Attribute>
+            </Attribute>
+        </RoleClass>
+        <RoleClass Name="OperationInputVariables" RefBaseClassPath="AutomationMLBaseRoleClassLib/AutomationMLBaseRole">
+            <Description>The list of AAS OperationVariableIn entities. In AML, the corresponding InternalElement with this role is a child of the InternalElement with the Operation role.</Description>
+        </RoleClass>
+        <RoleClass Name="OperationOutputVariables" RefBaseClassPath="AutomationMLBaseRoleClassLib/AutomationMLBaseRole">
+            <Description>The list of AAS OperationVariableOut entities. In AML, the corresponding InternalElement with this role is a child of the InternalElement with the Operation role.</Description>
+        </RoleClass>
+        <RoleClass Name="OperationInoutputVariables" RefBaseClassPath="AutomationMLBaseRoleClassLib/AutomationMLBaseRole">
+            <Description>The list of AAS OperationVariableOut entities. In AML, the corresponding InternalElement with this role is a child of the InternalElement with the Operation role.</Description>
+        </RoleClass>
+        <RoleClass Name="View" RefBaseClassPath="AutomationMLBaseRoleClassLib/AutomationMLBaseRole/Group">
+            <Description>A view is a collection of referable elements w.r.t. to a specific viewpoint of one or more stakeholders.</Description>
+            <Attribute Name="idShort" AttributeDataType="xs:string">
+                <Description>Identifying string of the element within its name space. Constraint AASd-001: In case of a referable element not being an identifiable element this id is mandatory and used for referring to the element in its name space. Constraint AASd-002: idShort shall only feature letters, digits, underscore (&quot;_&quot;); starting mandatory with a letter. Constraint AASd-003: idShort shall be matched case-insensitive. Note: In case of an identifiable element idShort is optional but recommended to be defined. It can be used for unique reference in its name space and thus allows better usability and a more performant implementation. In this case it is similar to the “BrowserPath” in OPC UA.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+            </Attribute>
+            <Attribute Name="category" AttributeDataType="xs:string">
+                <Description>The category is a value that gives further meta information w.r.t. to the class of the element. It affects the expected existence of attributes and the applicability of constraints.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/category"/>
+            </Attribute>
+            <Attribute Name="description" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/description"/>
+                <Attribute Name="aml-lang=EN"/>
+                <Attribute Name="aml-lang=DE"/>
+            </Attribute>
+            <Attribute Name="dataSpecification" AttributeDataType="xs:string">
+                <Description>Global reference to the data specification template used by the element.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:HasDataSpecification/dataSpecification"/>
+            </Attribute>
+            <Attribute Name="semanticId" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages. This attribute has the name of the label and has a value with the label written in the default language. The individual languages are modelled as child attributes. The names of the child attributes are the prefix “aml-lang=” with the expression of the language in compliance with RFC5646. At it, the values of the child attributes are the labels within the respective language.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:HasSemantics/semanticId"/>
+            </Attribute>
+        </RoleClass>
+        <RoleClass Name="ConceptDictionary" RefBaseClassPath="AutomationMLBaseRoleClassLib/AutomationMLBaseRole">
+            <Description>A dictionary contains elements that can be reused.</Description>
+            <Attribute Name="idShort" AttributeDataType="xs:string">
+                <Description>Identifying string of the element within its name space. Constraint AASd-001: In case of a referable element not being an identifiable element this id is mandatory and used for referring to the element in its name space. Constraint AASd-002: idShort shall only feature letters, digits, underscore (&quot;_&quot;); starting mandatory with a letter. Constraint AASd-003: idShort shall be matched case-insensitive. Note: In case of an identifiable element idShort is optional but recommended to be defined. It can be used for unique reference in its name space and thus allows better usability and a more performant implementation. In this case it is similar to the “BrowserPath” in OPC UA.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+            </Attribute>
+            <Attribute Name="category" AttributeDataType="xs:string">
+                <Description>The category is a value that gives further meta information w.r.t. to the class of the element. It affects the expected existence of attributes and the applicability of constraints.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/category"/>
+            </Attribute>
+            <Attribute Name="description" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/description"/>
+                <Attribute Name="aml-lang=EN" AttributeDataType="xs:string">
+                    <Value/>
+                </Attribute>
+                <Attribute Name="aml-lang=DE" AttributeDataType="xs:string">
+                    <Value/>
+                </Attribute>
+            </Attribute>
+        </RoleClass>
+        <RoleClass Name="ConceptDescription" RefBaseClassPath="AutomationMLBaseRoleClassLib/AutomationMLBaseRole">
+            <Description>Explanation: The semantics of a property or other elements that may have a semantic description is defined by a concept description. The description of the concept should follow a standardized schema (realized as data specification template).</Description>
+            <Attribute Name="idShort" AttributeDataType="xs:string">
+                <Description>Identifying string of the element within its name space. Constraint AASd-001: In case of a referable element not being an identifiable element this id is mandatory and used for referring to the element in its name space. Constraint AASd-002: idShort shall only feature letters, digits, underscore (&quot;_&quot;); starting mandatory with a letter. Constraint AASd-003: idShort shall be matched case-insensitive. Note: In case of an identifiable element idShort is optional but recommended to be defined. It can be used for unique reference in its name space and thus allows better usability and a more performant implementation. In this case it is similar to the “BrowserPath” in OPC UA.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+            </Attribute>
+            <Attribute Name="category" AttributeDataType="xs:string">
+                <Description>The category is a value that gives further meta information w.r.t. to the class of the element. It affects the expected existence of attributes and the applicability of constraints.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/category"/>
+            </Attribute>
+            <Attribute Name="description" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/description"/>
+                <Attribute Name="aml-lang=EN" AttributeDataType="xs:string"/>
+                <Attribute Name="aml-lang=DE" AttributeDataType="xs:string"/>
+            </Attribute>
+            <Attribute Name="identification">
+                <Description>Abstract attribute class for identification. Has the subattributes id and idType.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Identifiable/identification"/>
+                <Attribute Name="id" AttributeDataType="xs:string">
+                    <Description>Identifier of the element. Its type is defined in idType. Id is a subproperty of identification.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Identifier/id"/>
+                </Attribute>
+                <Attribute Name="idType" AttributeDataType="xs:string">
+                    <Description>Type of the Identifier, e.g. IRI, IRDI etc. The supported Identifier types are defined in the enumeration “IdentifierType”. IdType is a subproperty of identification.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Identifier/idType"/>
+                </Attribute>
+            </Attribute>
+            <Attribute Name="administration">
+                <Description>Abstract attribute for administration. Has the subattributes revision and version.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Identifiable/administration"/>
+                <Attribute Name="revision" AttributeDataType="xs:string">
+                    <Description>Revision of the element. Constraint AASd-005: A revision requires a version. This means, if there is no version there is no revision neither. Revision is a subproperty of administration.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:AdministrativeInformation/revision"/>
+                </Attribute>
+                <Attribute Name="version" AttributeDataType="xs:string">
+                    <Description>Version of the element. Version is a subproperty of administration.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:AdministrativeInformation/version"/>
+                </Attribute>
+            </Attribute>
+            <Attribute Name="dataSpecification" AttributeDataType="xs:string">
+                <Description>Global reference to the data specification template used by the element.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:HasDataSpecification/dataSpecification"/>
+            </Attribute>
+            <Attribute Name="isCaseOf" AttributeDataType="xs:string">
+                <Description>Global reference to an external definition the concept is compatible to or was derived from.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:ConceptDescription/isCaseOf"/>
+            </Attribute>
+        </RoleClass>
+        <RoleClass Name="DataSpecification" RefBaseClassPath="AutomationMLBaseRoleClassLib/AutomationMLBaseRole">
+            <Description>Description Role class of an element that has a data specification template. A template defines the additional attributes an element may or shall have.</Description>
+            <Attribute Name="idShort" AttributeDataType="xs:string">
+                <Description>Identifying string of the element within its name space. Constraint AASd-001: In case of a referable element not being an identifiable element this id is mandatory and used for referring to the element in its name space. Constraint AASd-002: idShort shall only feature letters, digits, underscore (&quot;_&quot;); starting mandatory with a letter. Constraint AASd-003: idShort shall be matched case-insensitive. Note: In case of an identifiable element idShort is optional but recommended to be defined. It can be used for unique reference in its name space and thus allows better usability and a more performant implementation. In this case it is similar to the “BrowserPath” in OPC UA.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+            </Attribute>
+            <Attribute Name="category" AttributeDataType="xs:string">
+                <Description>The category is a value that gives further meta information w.r.t. to the class of the element. It affects the expected existence of attributes and the applicability of constraints.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/category"/>
+            </Attribute>
+            <Attribute Name="description" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/description"/>
+                <Attribute Name="aml-lang=EN" AttributeDataType="xs:string">
+                    <Value/>
+                </Attribute>
+                <Attribute Name="aml-lang=DE" AttributeDataType="xs:string">
+                    <Value/>
+                </Attribute>
+            </Attribute>
+            <Attribute Name="identification">
+                <Description>Abstract attribute class for identification. Has the subattributes id and idType.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Identifiable/identification"/>
+                <Attribute Name="id" AttributeDataType="xs:string">
+                    <Description>Identifier of the element. Its type is defined in idType. Id is a subproperty of identification.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Identifier/id"/>
+                </Attribute>
+                <Attribute Name="idType" AttributeDataType="xs:string">
+                    <Description>Type of the Identifier, e.g. IRI, IRDI etc. The supported Identifier types are defined in the enumeration “IdentifierType”. IdType is a subproperty of identification.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Identifier/idType"/>
+                </Attribute>
+            </Attribute>
+            <Attribute Name="administration">
+                <Description>Abstract attribute for administration. Has the subattributes revision and version.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Identifiable/administration"/>
+                <Attribute Name="revision" AttributeDataType="xs:string">
+                    <Description>Revision of the element. Constraint AASd-005: A revision requires a version. This means, if there is no version there is no revision neither. Revision is a subproperty of administration.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:AdministrativeInformation/revision"/>
+                </Attribute>
+                <Attribute Name="version" AttributeDataType="xs:string">
+                    <Description>Version of the element. Version is a subproperty of administration.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:AdministrativeInformation/version"/>
+                </Attribute>
+            </Attribute>
+        </RoleClass>
+        <RoleClass Name="DataSpecificationContent" RefBaseClassPath="AutomationMLBaseRoleClassLib/AutomationMLBaseRole">
+            <Description>Content of the data specification template.</Description>
+        </RoleClass>
+        <RoleClass Name="Entity" RefBaseClassPath="AutomationMLBaseRoleClassLib/AutomationMLBaseRole">
+            <Description>An entity is a submodel element that is used to model entities. Constraint AASd-056: If the semanticId of a Entity submodel element references a ConceptDescription then the ConceptDescription/category shall be one of following values: ENTITY. The ConceptDescription describes the elements assigned to the entity via Entity/statement.</Description>
+            <Attribute Name="idShort" AttributeDataType="xs:string">
+                <Description>Identifying string of the element within its name space. Constraint AASd-001: In case of a referable element not being an identifiable element this id is mandatory and used for referring to the element in its name space. Constraint AASd-002: idShort shall only feature letters, digits, underscore (&quot;_&quot;); starting mandatory with a letter. Constraint AASd-003: idShort shall be matched case-insensitive. Note: In case of an identifiable element idShort is optional but recommended to be defined. It can be used for unique reference in its name space and thus allows better usability and a more performant implementation. In this case it is similar to the “BrowserPath” in OPC UA.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+            </Attribute>
+            <Attribute Name="category" AttributeDataType="xs:string">
+                <Description>The category is a value that gives further meta information w.r.t. to the class of the element. It affects the expected existence of attributes and the applicability of constraints.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/category"/>
+            </Attribute>
+            <Attribute Name="description" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/description"/>
+                <Attribute Name="aml-lang=EN"/>
+                <Attribute Name="aml-lang=DE"/>
+            </Attribute>
+            <Attribute Name="dataSpecification" AttributeDataType="xs:string">
+                <Description>Global reference to the data specification template used by the element.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:HasDataSpecification/dataSpecification"/>
+            </Attribute>
+            <Attribute Name="kind" AttributeDataType="xs:string">
+                <Description>Kind of the element: either template or instance.</Description>
+                <DefaultValue>Instance</DefaultValue>
+                <Value>Instance</Value>
+                <RefSemantic CorrespondingAttributePath="AAS:HasKind/kind"/>
+                <Constraint Name="">
+                    <NominalScaledType>
+                        <RequiredValue>Instance</RequiredValue>
+                        <RequiredValue>Type</RequiredValue>
+                    </NominalScaledType>
+                </Constraint>
+            </Attribute>
+            <Attribute Name="semanticId" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages. This attribute has the name of the label and has a value with the label written in the default language. The individual languages are modelled as child attributes. The names of the child attributes are the prefix “aml-lang=” with the expression of the language in compliance with RFC5646. At it, the values of the child attributes are the labels within the respective language.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:HasSemantics/semanticId"/>
+            </Attribute>
+            <Attribute Name="qualifier:[TYPE]=[VALUE]" AttributeDataType="xs:string">
+                <Description>A qualifier is a type-value-pair that makes additional statements w.r.t. the value of the element. [TYPE] is the value of the attribute type and [VALUE] is the value of the attribute value.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Qualifiable/qualifier"/>
+                <Attribute Name="type" AttributeDataType="xs:string">
+                    <Description>The type describes the type of the qualifier that is applied to the element.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/type"/>
+                </Attribute>
+                <Attribute Name="value" AttributeDataType="xs:string">
+                    <Description>The qualifier value is the value of the qualifier. Constraint AASd-006: if both, the value and the valueId are present then the value needs to be identical to the value of the referenced coded value in valueId.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/value"/>
+                </Attribute>
+                <Attribute Name="valueId" AttributeDataType="xs:string">
+                    <Description>Reference to the global unqiue id of a coded value.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/valueId"/>
+                </Attribute>
+            </Attribute>
+            <Attribute Name="statement" AttributeDataType="xs:string">
+                <Description>Describes statements applicable to the entity by a set of submodel elements, typically with a qualified value.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Entity/statement"/>
+            </Attribute>
+            <Attribute Name="entityType" AttributeDataType="xs:string">
+                <Description>Describes whether the entity is a co-managed entity or a self-managed entity.</Description>
+                <DefaultValue>SelfManagedEntity</DefaultValue>
+                <Value>SelfManagedEntity</Value>
+                <RefSemantic CorrespondingAttributePath="AAS:Entity/entityType"/>
+                <Constraint Name="">
+                    <NominalScaledType>
+                        <RequiredValue>CoManagedEntity</RequiredValue>
+                        <RequiredValue>SelfManagedEntity</RequiredValue>
+                    </NominalScaledType>
+                </Constraint>
+            </Attribute>
+            <Attribute Name="specificAssetId" AttributeDataType="xs:string">
+                <Description>Reference to an identifier key value pair representing a specific identifier of the asset represented by the asset administration shell. See Constraint AASd-014</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Entity/specificAssetId"/>
+            </Attribute>
+            <Attribute Name="globalAssetId" AttributeDataType="xs:string">
+                <Description>Reference to the asset the entity is representing. Constraint AASd-014: Either the attribute globalAssetId or specificAssetId of an Entity must be set if Entity/entityType is set to &quot;SelfManagedEntity&quot;. They are not existing otherwise.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Entity/globalAssetId"/>
+            </Attribute>
+        </RoleClass>
+        <RoleClass Name="BasicEvent" RefBaseClassPath="AutomationMLBaseRoleClassLib/AutomationMLBaseRole">
+            <Attribute Name="idShort" AttributeDataType="xs:string">
+                <Description>Identifying string of the element within its name space. Constraint AASd-001: In case of a referable element not being an identifiable element this id is mandatory and used for referring to the element in its name space. Constraint AASd-002: idShort shall only feature letters, digits, underscore (&quot;_&quot;); starting mandatory with a letter. Constraint AASd-003: idShort shall be matched case-insensitive. Note: In case of an identifiable element idShort is optional but recommended to be defined. It can be used for unique reference in its name space and thus allows better usability and a more performant implementation. In this case it is similar to the “BrowserPath” in OPC UA.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+            </Attribute>
+            <Attribute Name="category" AttributeDataType="xs:string">
+                <Description>The category is a value that gives further meta information w.r.t. to the class of the element. It affects the expected existence of attributes and the applicability of constraints.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/category"/>
+            </Attribute>
+            <Attribute Name="description" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/description"/>
+                <Attribute Name="aml-lang=EN"/>
+                <Attribute Name="aml-lang=DE"/>
+            </Attribute>
+            <Attribute Name="dataSpecification" AttributeDataType="xs:string">
+                <Description>Global reference to the data specification template used by the element.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:HasDataSpecification/dataSpecification"/>
+            </Attribute>
+            <Attribute Name="kind" AttributeDataType="xs:string">
+                <Description>Kind of the element: either template or instance.</Description>
+                <DefaultValue>Instance</DefaultValue>
+                <Value>Instance</Value>
+                <RefSemantic CorrespondingAttributePath="AAS:HasKind/kind"/>
+                <Constraint Name="">
+                    <NominalScaledType>
+                        <RequiredValue>Instance</RequiredValue>
+                        <RequiredValue>Type</RequiredValue>
+                    </NominalScaledType>
+                </Constraint>
+            </Attribute>
+            <Attribute Name="semanticId" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages. This attribute has the name of the label and has a value with the label written in the default language. The individual languages are modelled as child attributes. The names of the child attributes are the prefix “aml-lang=” with the expression of the language in compliance with RFC5646. At it, the values of the child attributes are the labels within the respective language.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:HasSemantics/semanticId"/>
+            </Attribute>
+            <Attribute Name="qualifier:[TYPE]=[VALUE]" AttributeDataType="xs:string">
+                <Description>A qualifier is a type-value-pair that makes additional statements w.r.t. the value of the element. [TYPE] is the value of the attribute type and [VALUE] is the value of the attribute value.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Qualifiable/qualifier"/>
+                <Attribute Name="type" AttributeDataType="xs:string">
+                    <Description>The type describes the type of the qualifier that is applied to the element.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/type"/>
+                </Attribute>
+                <Attribute Name="value" AttributeDataType="xs:string">
+                    <Description>The qualifier value is the value of the qualifier. Constraint AASd-006: if both, the value and the valueId are present then the value needs to be identical to the value of the referenced coded value in valueId.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/value"/>
+                </Attribute>
+                <Attribute Name="valueId" AttributeDataType="xs:string">
+                    <Description>Reference to the global unqiue id of a coded value.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/valueId"/>
+                </Attribute>
+            </Attribute>
+            <Attribute Name="observed" AttributeDataType="xs:string">
+                <RefSemantic CorrespondingAttributePath="AAS:BasicEvent/observed"/>
+            </Attribute>
+        </RoleClass>
+        <RoleClass Name="Range" RefBaseClassPath="AutomationMLBaseRoleClassLib/AutomationMLBaseRole">
+            <Attribute Name="idShort" AttributeDataType="xs:string">
+                <Description>Identifying string of the element within its name space. Constraint AASd-001: In case of a referable element not being an identifiable element this id is mandatory and used for referring to the element in its name space. Constraint AASd-002: idShort shall only feature letters, digits, underscore (&quot;_&quot;); starting mandatory with a letter. Constraint AASd-003: idShort shall be matched case-insensitive. Note: In case of an identifiable element idShort is optional but recommended to be defined. It can be used for unique reference in its name space and thus allows better usability and a more performant implementation. In this case it is similar to the “BrowserPath” in OPC UA.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+            </Attribute>
+            <Attribute Name="category" AttributeDataType="xs:string">
+                <Description>The category is a value that gives further meta information w.r.t. to the class of the element. It affects the expected existence of attributes and the applicability of constraints.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/category"/>
+            </Attribute>
+            <Attribute Name="description" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/description"/>
+                <Attribute Name="aml-lang=EN"/>
+                <Attribute Name="aml-lang=DE"/>
+            </Attribute>
+            <Attribute Name="dataSpecification" AttributeDataType="xs:string">
+                <Description>Global reference to the data specification template used by the element.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:HasDataSpecification/dataSpecification"/>
+            </Attribute>
+            <Attribute Name="kind" AttributeDataType="xs:string">
+                <Description>Kind of the element: either template or instance.</Description>
+                <DefaultValue>Instance</DefaultValue>
+                <Value>Instance</Value>
+                <RefSemantic CorrespondingAttributePath="AAS:HasKind/kind"/>
+                <Constraint Name="">
+                    <NominalScaledType>
+                        <RequiredValue>Instance</RequiredValue>
+                        <RequiredValue>Type</RequiredValue>
+                    </NominalScaledType>
+                </Constraint>
+            </Attribute>
+            <Attribute Name="semanticId" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages. This attribute has the name of the label and has a value with the label written in the default language. The individual languages are modelled as child attributes. The names of the child attributes are the prefix “aml-lang=” with the expression of the language in compliance with RFC5646. At it, the values of the child attributes are the labels within the respective language.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:HasSemantics/semanticId"/>
+            </Attribute>
+            <Attribute Name="qualifier:[TYPE]=[VALUE]" AttributeDataType="xs:string">
+                <Description>A qualifier is a type-value-pair that makes additional statements w.r.t. the value of the element. [TYPE] is the value of the attribute type and [VALUE] is the value of the attribute value.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Qualifiable/qualifier"/>
+                <Attribute Name="type" AttributeDataType="xs:string">
+                    <Description>The type describes the type of the qualifier that is applied to the element.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/type"/>
+                </Attribute>
+                <Attribute Name="value" AttributeDataType="xs:string">
+                    <Description>The qualifier value is the value of the qualifier. Constraint AASd-006: if both, the value and the valueId are present then the value needs to be identical to the value of the referenced coded value in valueId.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/value"/>
+                </Attribute>
+                <Attribute Name="valueId" AttributeDataType="xs:string">
+                    <Description>Reference to the global unqiue id of a coded value.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/valueId"/>
+                </Attribute>
+            </Attribute>
+            <Attribute Name="min" AttributeDataType="xs:string">
+                <Description>Reference to the global unique id if a coded value.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Range/min"/>
+            </Attribute>
+            <Attribute Name="max" AttributeDataType="xs:string">
+                <RefSemantic CorrespondingAttributePath="AAS:Range/max"/>
+            </Attribute>
+        </RoleClass>
+        <RoleClass Name="MultiLanguageProperty" RefBaseClassPath="AutomationMLBaseRoleClassLib/AutomationMLBaseRole">
+            <Attribute Name="idShort" AttributeDataType="xs:string">
+                <Description>Identifying string of the element within its name space. Constraint AASd-001: In case of a referable element not being an identifiable element this id is mandatory and used for referring to the element in its name space. Constraint AASd-002: idShort shall only feature letters, digits, underscore (&quot;_&quot;); starting mandatory with a letter. Constraint AASd-003: idShort shall be matched case-insensitive. Note: In case of an identifiable element idShort is optional but recommended to be defined. It can be used for unique reference in its name space and thus allows better usability and a more performant implementation. In this case it is similar to the “BrowserPath” in OPC UA.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+            </Attribute>
+            <Attribute Name="category" AttributeDataType="xs:string">
+                <Description>The category is a value that gives further meta information w.r.t. to the class of the element. It affects the expected existence of attributes and the applicability of constraints.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/category"/>
+            </Attribute>
+            <Attribute Name="description" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/description"/>
+                <Attribute Name="aml-lang=EN"/>
+                <Attribute Name="aml-lang=DE"/>
+            </Attribute>
+            <Attribute Name="dataSpecification" AttributeDataType="xs:string">
+                <Description>Global reference to the data specification template used by the element.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:HasDataSpecification/dataSpecification"/>
+            </Attribute>
+            <Attribute Name="kind" AttributeDataType="xs:string">
+                <Description>Kind of the element: either template or instance.</Description>
+                <DefaultValue>Instance</DefaultValue>
+                <Value>Instance</Value>
+                <RefSemantic CorrespondingAttributePath="AAS:HasKind/kind"/>
+                <Constraint Name="">
+                    <NominalScaledType>
+                        <RequiredValue>Instance</RequiredValue>
+                        <RequiredValue>Type</RequiredValue>
+                    </NominalScaledType>
+                </Constraint>
+            </Attribute>
+            <Attribute Name="semanticId" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages. This attribute has the name of the label and has a value with the label written in the default language. The individual languages are modelled as child attributes. The names of the child attributes are the prefix “aml-lang=” with the expression of the language in compliance with RFC5646. At it, the values of the child attributes are the labels within the respective language.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:HasSemantics/semanticId"/>
+            </Attribute>
+            <Attribute Name="qualifier:[TYPE]=[VALUE]" AttributeDataType="xs:string">
+                <Description>A qualifier is a type-value-pair that makes additional statements w.r.t. the value of the element. [TYPE] is the value of the attribute type and [VALUE] is the value of the attribute value.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Qualifiable/qualifier"/>
+                <Attribute Name="type" AttributeDataType="xs:string">
+                    <Description>The type describes the type of the qualifier that is applied to the element.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/type"/>
+                </Attribute>
+                <Attribute Name="value" AttributeDataType="xs:string">
+                    <Description>The qualifier value is the value of the qualifier. Constraint AASd-006: if both, the value and the valueId are present then the value needs to be identical to the value of the referenced coded value in valueId.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/value"/>
+                </Attribute>
+                <Attribute Name="valueId" AttributeDataType="xs:string">
+                    <Description>Reference to the global unqiue id of a coded value.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:Qualifier/valueId"/>
+                </Attribute>
+            </Attribute>
+            <Attribute Name="value" AttributeDataType="">
+                <Description>The value of the property instance.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:MultiLanguageProperty/value"/>
+            </Attribute>
+            <Attribute Name="valueId" AttributeDataType="xs:string">
+                <Description>Reference to the global unique id if a coded value.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:MultiLanguageProperty/valueId"/>
+            </Attribute>
+        </RoleClass>
+    </RoleClassLib>
+    <RoleClassLib Name="AutomationMLBaseRoleClassLib">
+        <Description>Automation Markup Language Base Role Class Library - Part 1 Content extended with Part 3 and Part 4 Content</Description>
+        <Version>2.2.2</Version>
+        <RoleClass Name="AutomationMLBaseRole">
+            <RoleClass Name="Group" RefBaseClassPath="AutomationMLBaseRole">
+                <Attribute Name="AssociatedFacet" AttributeDataType="xs:string"/>
+                <RoleClass Name="InterlockingSourceGroup" RefBaseClassPath="Group"/>
+                <RoleClass Name="InterlockingTargetGroup" RefBaseClassPath="Group"/>
+            </RoleClass>
+            <RoleClass Name="Facet" RefBaseClassPath="AutomationMLBaseRole"/>
+            <RoleClass Name="Port" RefBaseClassPath="AutomationMLBaseRole">
+                <Attribute Name="Direction" AttributeDataType="xs:string"/>
+                <Attribute Name="Cardinality">
+                    <Attribute Name="MinOccur" AttributeDataType="xs:unsignedInt"/>
+                    <Attribute Name="MaxOccur" AttributeDataType="xs:unsignedInt"/>
+                </Attribute>
+                <Attribute Name="Category" AttributeDataType="xs:string"/>
+                <ExternalInterface ID="9942bd9c-c19d-44e4-a197-11b9edf264e7" Name="ConnectionPoint" RefBaseClassPath="AutomationMLInterfaceClassLib/AutomationMLBaseInterface/PortConnector"/>
+            </RoleClass>
+            <RoleClass Name="Resource" RefBaseClassPath="AutomationMLBaseRole"/>
+            <RoleClass Name="Product" RefBaseClassPath="AutomationMLBaseRole"/>
+            <RoleClass Name="Process" RefBaseClassPath="AutomationMLBaseRole"/>
+            <RoleClass Name="Structure" RefBaseClassPath="AutomationMLBaseRole">
+                <RoleClass Name="ProductStructure" RefBaseClassPath="Structure"/>
+                <RoleClass Name="ProcessStructure" RefBaseClassPath="Structure"/>
+                <RoleClass Name="ResourceStructure" RefBaseClassPath="Structure"/>
+            </RoleClass>
+            <RoleClass Name="PropertySet" RefBaseClassPath="AutomationMLBaseRole"/>
+            <RoleClass Name="Frame" RefBaseClassPath="AutomationMLBaseRole"/>
+            <RoleClass Name="LogicObject" RefBaseClassPath="AutomationMLBaseRole"/>
+        </RoleClass>
+    </RoleClassLib>
+    <RoleClassLib Name="AutomationMLBPRRoleClassLib">
+        <Version>1.0.0</Version>
+        <RoleClass Name="ExternalData" RefBaseClassPath="AutomationMLBaseRoleClassLib/AutomationMLBaseRole"/>
+    </RoleClassLib>
+    <SystemUnitClassLib Name="AssetAdministrationShellDataSpecificationTemplates">
+        <Version>0</Version>
+        <SystemUnitClass ID="572c0568-4019-40ec-bfc4-a3a82dc6eed4" Name="DataSpecificationIEC61360Template">
+            <Description>An AAS Data Specification template for IEC61369. A template consists of the DataSpecificationContent containing the additional attributes to be added to the element instance that references the data specification template and meta information about the template itself (this is why DataSpecification inherits from Identifiable). In UML these are two separated classes.</Description>
+            <Attribute Name="idShort" AttributeDataType="xs:string">
+                <Description>Identifying string of the element within its name space. Constraint AASd-001: In case of a referable element not being an identifiable element this id is mandatory and used for referring to the element in its name space. Constraint AASd-002: idShort shall only feature letters, digits, underscore (&quot;_&quot;); starting mandatory with a letter. Constraint AASd-003: idShort shall be matched case-insensitive. Note: In case of an identifiable element idShort is optional but recommended to be defined. It can be used for unique reference in its name space and thus allows better usability and a more performant implementation. In this case it is similar to the “BrowserPath” in OPC UA.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/idShort"/>
+            </Attribute>
+            <Attribute Name="category" AttributeDataType="xs:string">
+                <Description>The category is a value that gives further meta information w.r.t. to the class of the element. It affects the expected existence of attributes and the applicability of constraints.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/category"/>
+            </Attribute>
+            <Attribute Name="description" AttributeDataType="xs:string">
+                <Description>Description or comments on the element. The description can be provided in several languages.</Description>
+                <Value/>
+                <RefSemantic CorrespondingAttributePath="AAS:Referable/description"/>
+                <Attribute Name="aml-lang=EN" AttributeDataType="xs:string">
+                    <Value/>
+                </Attribute>
+                <Attribute Name="aml-lang=DE" AttributeDataType="xs:string">
+                    <Value/>
+                </Attribute>
+            </Attribute>
+            <Attribute Name="identification">
+                <Description>Abstract attribute class for identification. Has the subattributes id and idType.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Identifiable/identification"/>
+                <Attribute Name="id" AttributeDataType="xs:string">
+                    <Description>Identifier of the element. Its type is defined in idType. Id is a subproperty of identification.</Description>
+                    <Value>http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360</Value>
+                    <RefSemantic CorrespondingAttributePath="AAS:Identifier/id"/>
+                </Attribute>
+                <Attribute Name="idType" AttributeDataType="xs:string">
+                    <Description>Type of the Identifier, e.g. IRI, IRDI etc. The supported Identifier types are defined in the enumeration “IdentifierType”. IdType is a subproperty of identification.</Description>
+                    <Value>IRI</Value>
+                    <RefSemantic CorrespondingAttributePath="AAS:Identifier/idType"/>
+                </Attribute>
+            </Attribute>
+            <Attribute Name="administration">
+                <Description>Abstract attribute for administration. Has the subattributes revision and version.</Description>
+                <RefSemantic CorrespondingAttributePath="AAS:Identifiable/administration"/>
+                <Attribute Name="revision" AttributeDataType="xs:string">
+                    <Description>Revision of the element. Constraint AASd-005: A revision requires a version. This means, if there is no version there is no revision neither. Revision is a subproperty of administration.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:AdministrativeInformation/revision"/>
+                </Attribute>
+                <Attribute Name="version" AttributeDataType="xs:string">
+                    <Description>Version of the element. Version is a subproperty of administration.</Description>
+                    <Value/>
+                    <RefSemantic CorrespondingAttributePath="AAS:AdministrativeInformation/version"/>
+                </Attribute>
+            </Attribute>
+            <SupportedRoleClass RefRoleClassPath="AssetAdministrationShellRoleClassLib/DataSpecification"/>
+            <SystemUnitClass ID="8c019d8e-7ddd-4283-aa63-1747021c3d1b" Name="DataSpecificationIEC61360">
+                <Description>The content of an AAS Data Specification template for IEC61360.</Description>
+                <Attribute Name="preferredName" AttributeDataType="xs:string">
+                    <Description>Identifies the attribute hierarchy for preferredName in above attribute hierachy. Subordinate attributes are designated by the country code information (see aml-lang literal).</Description>
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/preferredName"/>
+                </Attribute>
+                <Attribute Name="shortName" AttributeDataType="xs:string">
+                    <Description>Identifies the attribute for shortName in above attribute hierarchy.</Description>
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/shortName"/>
+                </Attribute>
+                <Attribute Name="unit" AttributeDataType="xs:string">
+                    <Description>Identifies the attribute for unit in above attribute hierarchy.</Description>
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/unit"/>
+                </Attribute>
+                <Attribute Name="unitId" AttributeDataType="xs:string">
+                    <Description>Identifies the attribute for unitId in above attribute hierarchy in its string serialization.</Description>
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/unitId"/>
+                </Attribute>
+                <Attribute Name="sourceOfDefinition" AttributeDataType="xs:string">
+                    <Description>Identifies the attribute for sourceOfDefinition in above attribute hierachy. Subordinate attributes are designated by the country code information (see aml-lang literal).</Description>
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/sourceOfDefinition"/>
+                </Attribute>
+                <Attribute Name="symbol" AttributeDataType="xs:string">
+                    <Description>Identifies the attribute for symbol in above attribute hierarchy.</Description>
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/symbol"/>
+                </Attribute>
+                <Attribute Name="dataType" AttributeDataType="xs:string">
+                    <Description>Identifies the attribute for dataType in above attribute hierarchy.</Description>
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/dataType"/>
+                </Attribute>
+                <Attribute Name="definition" AttributeDataType="xs:string">
+                    <Description>Identifies the attribute for definition in above attribute hierachy. Subordinate attributes are designated by the country code information (see aml-lang literal).</Description>
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/definition"/>
+                </Attribute>
+                <Attribute Name="valueFormat" AttributeDataType="xs:string">
+                    <Description>Identifies the attribute for valueFormat in above attribute hierarchy.</Description>
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/valueFormat"/>
+                </Attribute>
+                <Attribute Name="valueList" AttributeDataType="xs:string">
+                    <Description>Identifies the attribute for valueList in above attribute hierarchy.</Description>
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/valueList"/>
+                </Attribute>
+                <Attribute Name="value" AttributeDataType="xs:string">
+                    <Description>The attribute value.</Description>
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/value"/>
+                </Attribute>
+                <Attribute Name="valueId" AttributeDataType="xs:string">
+                    <Description>The id for the value.</Description>
+                    <RefSemantic CorrespondingAttributePath="IEC:DataSpecificationIEC61360/valueId"/>
+                </Attribute>
+                <SupportedRoleClass RefRoleClassPath="AssetAdministrationShellRoleClassLib/DataSpecificationContent"/>
+            </SystemUnitClass>
+        </SystemUnitClass>
+    </SystemUnitClassLib>
+</CAEXFile>


### PR DESCRIPTION
This bugfix fixes a potential NPE while AML de-/serializing and now enables AssetInformation.specificAssetId to be serialized.
Additionally, a new unit test using the simple example has been introduced.

However, serialization to AML is currently still loosing information, because AML serialization specification is based on AAS Part 1 v2.0 and therefore does not support all elements and properties introduced in v3.0.

**Before merging this PR to main, version must be increased acordingly.**