### PR TITLE
fix: fix logic for screaming snake case during enum deserialization

### DIFF
--- a/dataformat-core/src/main/java/io/adminshell/aas/v3/dataformat/core/util/AasUtils.java
+++ b/dataformat-core/src/main/java/io/adminshell/aas/v3/dataformat/core/util/AasUtils.java
@@ -30,7 +30,6 @@ import io.adminshell.aas.v3.model.Referable;
 import io.adminshell.aas.v3.model.Reference;
 import io.adminshell.aas.v3.model.Submodel;
 import io.adminshell.aas.v3.model.impl.DefaultKey;
-import io.adminshell.aas.v3.model.impl.DefaultReference;
 import java.beans.IntrospectionException;
 import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
@@ -47,6 +46,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -308,15 +308,20 @@ public class AasUtils {
         if (input == null || input.isEmpty()) {
             return result;
         }
-        result += input.charAt(0);
-        for (int i = 1; i < input.length(); i++) {
-            char currentChar = input.charAt(i);
-            if (Character.isUpperCase(currentChar)) {
-                result += UNDERSCORE;
+        if (StringUtils.isAllUpperCase(input)) {
+            result = input;
+        } else {
+            result += input.charAt(0);
+            for (int i = 1; i < input.length(); i++) {
+                char currentChar = input.charAt(i);
+                if (Character.isUpperCase(currentChar)) {
+                    result += UNDERSCORE;
+                }
+                result += currentChar;
             }
-            result += Character.toUpperCase(currentChar);
         }
-        return result;
+
+        return result.toUpperCase();
     }
 
     /**

--- a/dataformat-core/src/test/java/io/adminshell/aas/v3/dataformat/core/AasUtilsTest.java
+++ b/dataformat-core/src/test/java/io/adminshell/aas/v3/dataformat/core/AasUtilsTest.java
@@ -34,4 +34,28 @@ public class AasUtilsTest {
         Assert.assertEquals(KeyType.ID_SHORT, reference.getKeys().get(0).getIdType());
         Assert.assertEquals("Temperature", reference.getKeys().get(0).getValue());
     }
+
+    @Test
+    public void deserializeEnumName_IdShort_to_ID_SHORT(){
+        String input = "IdShort";
+        String result = AasUtils.deserializeEnumName(input);
+
+        Assert.assertEquals("ID_SHORT", result);
+    }
+
+    @Test
+    public void deserializeEnumName_Iri_to_IRI(){
+        String input = "Iri";
+        String result = AasUtils.deserializeEnumName(input);
+
+        Assert.assertEquals("IRI", result);
+    }
+
+    @Test
+    public void deserializeEnumName_IRI_to_IRI(){
+        String input = "IRI";
+        String result = AasUtils.deserializeEnumName(input);
+
+        Assert.assertEquals("IRI", result);
+    }
 }


### PR DESCRIPTION
There was a problem during Enum deserialization. The identifier type value "Irdi" or "Iri" or "IRI" was always converted to "I_R_I" but the enum value in IdentifierType is IRI or IRDI.

I fixed the logic to use correct camelCase to screaming snake case conversion. If a value is already uppercase it is now skipped to avoid a conversion to e.g. "I_R_I"